### PR TITLE
feat: make time-series chart render mode configurable (line or stacked area)

### DIFF
--- a/backend/src/o11ylite/store/events/query_schema.clj
+++ b/backend/src/o11ylite/store/events/query_schema.clj
@@ -133,7 +133,8 @@
   [:map {:closed true}
    [:type [:= "time_series"]]
    [:bucket_ms {:optional true} [:int {:min 1}]]
-   [:overlay {:optional true} :boolean]])
+   [:overlay {:optional true} :boolean]
+   [:render_as {:optional true} [:enum "line" "stacked_area"]]])
 
 ;; DEFERRED: Heatmap visualization is deferred to post-v1.
 ;; Decision: Heatmap should be a "smart visualization" - when user selects heatmap,

--- a/backend/src/o11ylite/store/metrics/query_schema.clj
+++ b/backend/src/o11ylite/store/metrics/query_schema.clj
@@ -119,7 +119,8 @@
   [:map {:closed true}
    [:type [:= "time_series"]]
    [:bucket_ms {:optional true} [:int {:min 1}]]
-   [:overlay {:optional true} :boolean]])
+   [:overlay {:optional true} :boolean]
+   [:render_as {:optional true} [:enum "line" "stacked_area"]]])
 
 (def visualization
   "Visualization config for metrics queries. Currently only time_series is supported."

--- a/backend/test/o11ylite/store/events/query_schema_test.clj
+++ b/backend/test/o11ylite/store/events/query_schema_test.clj
@@ -85,6 +85,17 @@
                  :aggregations [{:id "A" :field "*" :function "count"}]
                  :visualization {:type "time_series" :bucket_ms 60000}})))
 
+  (testing "time_series render_as enum"
+    (is (valid? {:time_range {:start 1702000000000 :end 1702003600000}
+                 :aggregations [{:id "A" :field "*" :function "count"}]
+                 :visualization {:type "time_series" :render_as "line"}}))
+    (is (valid? {:time_range {:start 1702000000000 :end 1702003600000}
+                 :aggregations [{:id "A" :field "*" :function "count"}]
+                 :visualization {:type "time_series" :render_as "stacked_area"}}))
+    (is (invalid? {:time_range {:start 1702000000000 :end 1702003600000}
+                   :aggregations [{:id "A" :field "*" :function "count"}]
+                   :visualization {:type "time_series" :render_as "pie"}})))
+
   ;; DEFERRED: Heatmap visualization is deferred to post-v1.
   ;; Schema validation is kept to ensure API contract is stable when implemented.
   (testing "heatmap visualization requires exactly one group_by (DEFERRED)"

--- a/backend/test/o11ylite/store/metrics/query_schema_test.clj
+++ b/backend/test/o11ylite/store/metrics/query_schema_test.clj
@@ -231,6 +231,27 @@
                    :metrics [{:id "A" :name "cpu.utilization" :agg "avg"}]}))))
 
 ;; ---------------------------------------------------------
+;; Visualization Validation
+
+(deftest visualization-validation-test
+  (testing "visualization is optional (defaults to time_series for metrics)"
+    (is (valid? {:time_range {:start 1702000000000 :end 1702003600000}
+                 :metrics [{:id "A" :name "cpu.utilization" :agg "avg"}]})))
+
+  (testing "render_as enum accepts line and stacked_area"
+    (is (valid? {:time_range {:start 1702000000000 :end 1702003600000}
+                 :metrics [{:id "A" :name "cpu.utilization" :agg "avg"}]
+                 :visualization {:type "time_series" :render_as "line"}}))
+    (is (valid? {:time_range {:start 1702000000000 :end 1702003600000}
+                 :metrics [{:id "A" :name "cpu.utilization" :agg "avg"}]
+                 :visualization {:type "time_series" :render_as "stacked_area"}})))
+
+  (testing "render_as rejects unknown values"
+    (is (invalid? {:time_range {:start 1702000000000 :end 1702003600000}
+                   :metrics [{:id "A" :name "cpu.utilization" :agg "avg"}]
+                   :visualization {:type "time_series" :render_as "bar"}}))))
+
+;; ---------------------------------------------------------
 ;; Full Query Examples
 
 (deftest full-query-examples-test

--- a/frontend/src/components/results/time-series/results-time-series.tsx
+++ b/frontend/src/components/results/time-series/results-time-series.tsx
@@ -18,6 +18,7 @@ export function ResultsTimeSeries({
 }) {
   const result = data.data as TimeSeriesQueryResult
   const overlay = visualization.overlay ?? false
+  const renderAs = visualization.render_as ?? "line"
 
   const metricGroups = useMemo(() => groupByMetric(result), [result])
 
@@ -33,12 +34,19 @@ export function ResultsTimeSeries({
           <TimeSeriesSettings
             overlay={overlay}
             onOverlayChange={(value) => onVisualizationChange({ ...visualization, overlay: value })}
+            renderAs={renderAs}
+            onRenderAsChange={(value) => onVisualizationChange({ ...visualization, render_as: value })}
           />
         </div>
       )}
 
       {overlay ? (
-        <TimeSeriesChart data={result} connectNulls={connectNulls} units={result.units} />
+        <TimeSeriesChart
+          data={result}
+          connectNulls={connectNulls}
+          units={result.units}
+          renderAs={renderAs}
+        />
       ) : (
         <div className="flex flex-col gap-4">
           {metricGroups.map(([name, subset]) => (
@@ -49,6 +57,7 @@ export function ResultsTimeSeries({
               connectNulls={connectNulls}
               shortLegendLabels
               units={result.units}
+              renderAs={renderAs}
             />
           ))}
         </div>

--- a/frontend/src/components/results/time-series/time-series-chart.tsx
+++ b/frontend/src/components/results/time-series/time-series-chart.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, useCallback, useRef } from "react"
-import { CartesianGrid, Line, LineChart, XAxis, YAxis, ReferenceArea } from "recharts"
+import { Area, CartesianGrid, ComposedChart, Line, XAxis, YAxis, ReferenceArea } from "recharts"
 
-import type { TimeSeriesQueryResult } from "@/types"
+import type { TimeSeriesQueryResult, TimeSeriesRenderAs } from "@/types"
 import { useTimeRange } from "@/hooks/use-time-range"
 import {
   type ChartConfig,
@@ -26,6 +26,8 @@ interface TimeSeriesChartProps {
   shortLegendLabels?: boolean
   // Metric name -> OTel unit string, from the query response
   units?: Record<string, string | null>
+  // How to draw each series. Defaults to "line".
+  renderAs?: TimeSeriesRenderAs
 }
 
 export function TimeSeriesChart({
@@ -34,10 +36,15 @@ export function TimeSeriesChart({
   connectNulls = false,
   shortLegendLabels = false,
   units,
+  renderAs = "line",
 }: TimeSeriesChartProps) {
+  // Stacked area requires numeric values at every bucket -- otherwise the stack
+  // develops holes. Zero-fill missing points only for the stacked path; the
+  // line path keeps nulls so real gaps remain visible.
+  const isStackedArea = renderAs === "stacked_area"
   const { chartData, seriesMeta } = useMemo(
-    () => transformData(data, { shortLegendLabels }),
-    [data, shortLegendLabels]
+    () => transformData(data, { shortLegendLabels, zeroFillNulls: isStackedArea }),
+    [data, shortLegendLabels, isStackedArea]
   )
   const showLegend = seriesMeta.length > 1
   const { setRange } = useTimeRange()
@@ -124,7 +131,7 @@ export function TimeSeriesChart({
         className="h-[240px] w-full py-2 px-2 touch-pan-y"
         onPointerMove={handlePointerMove}
       >
-        <LineChart
+        <ComposedChart
           accessibilityLayer
           data={chartData}
           onMouseDown={handleMouseDown}
@@ -179,17 +186,35 @@ export function TimeSeriesChart({
             }
           />
           {showLegend && <ChartLegend content={<ChartLegendContent />} />}
-          {seriesMeta.map((series) => (
-            <Line
-              key={series.key}
-              dataKey={series.key}
-              type="monotone"
-              stroke={series.color}
-              strokeWidth={2}
-              dot={{ fill: series.color, strokeWidth: 0, r: 2 }}
-              connectNulls={connectNulls}
-            />
-          ))}
+          {seriesMeta.map((series) =>
+            isStackedArea ? (
+              <Area
+                key={series.key}
+                dataKey={series.key}
+                type="monotone"
+                stackId="stack"
+                stroke={series.color}
+                strokeWidth={1}
+                fill={series.color}
+                fillOpacity={0.4}
+                // Stacked areas are already zero-filled in transformData, so
+                // connectNulls has no effect -- pass true for safety.
+                connectNulls
+                isAnimationActive={false}
+                activeDot={{ r: 3 }}
+              />
+            ) : (
+              <Line
+                key={series.key}
+                dataKey={series.key}
+                type="monotone"
+                stroke={series.color}
+                strokeWidth={2}
+                dot={{ fill: series.color, strokeWidth: 0, r: 2 }}
+                connectNulls={connectNulls}
+              />
+            )
+          )}
           {refAreaLeft !== null && refAreaRight !== null && (
             <ReferenceArea
               x1={refAreaLeft}
@@ -200,7 +225,7 @@ export function TimeSeriesChart({
               fillOpacity={0.3}
             />
           )}
-        </LineChart>
+        </ComposedChart>
       </ChartContainer>
     </div>
   )

--- a/frontend/src/components/results/time-series/time-series-settings.tsx
+++ b/frontend/src/components/results/time-series/time-series-settings.tsx
@@ -1,18 +1,30 @@
 import { Settings2 } from "lucide-react"
 
+import type { TimeSeriesRenderAs } from "@/types"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 
 interface TimeSeriesSettingsProps {
   overlay: boolean
   onOverlayChange: (value: boolean) => void
+  renderAs: TimeSeriesRenderAs
+  onRenderAsChange: (value: TimeSeriesRenderAs) => void
 }
 
 export function TimeSeriesSettings({
   overlay,
   onOverlayChange,
+  renderAs,
+  onRenderAsChange,
 }: TimeSeriesSettingsProps) {
   return (
     <Popover>
@@ -22,9 +34,30 @@ export function TimeSeriesSettings({
           <span className="sr-only">Chart settings</span>
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-56" align="end">
+      <PopoverContent className="w-64" align="end">
         <div className="space-y-4">
           <h4 className="font-medium text-sm">Chart Settings</h4>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="render-as-select" className="text-sm">
+              Render as
+            </Label>
+            <Select
+              value={renderAs}
+              onValueChange={(v) => onRenderAsChange(v as TimeSeriesRenderAs)}
+            >
+              <SelectTrigger
+                id="render-as-select"
+                size="sm"
+                className="w-auto min-w-[130px] text-xs"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="line">Lines</SelectItem>
+                <SelectItem value="stacked_area">Stacked area</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
           <div className="flex items-center justify-between">
             <Label htmlFor="overlay-switch" className="text-sm">
               Overlay charts

--- a/frontend/src/components/results/time-series/utils.test.ts
+++ b/frontend/src/components/results/time-series/utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest"
+
+import type { TimeSeriesQueryResult } from "@/types"
+import { transformData } from "./utils"
+
+function makeResult(): TimeSeriesQueryResult {
+  // Two series over three buckets. Series A has a gap at t=1; series B is full.
+  return {
+    start_ms: 0,
+    end_ms: 30,
+    bucket_ms: 10,
+    units: { hits: null },
+    series: [
+      {
+        name: "hits",
+        labels: { host: "a" },
+        data: [
+          { timestamp: 0, value: 1 },
+          { timestamp: 20, value: 3 },
+        ],
+      },
+      {
+        name: "hits",
+        labels: { host: "b" },
+        data: [
+          { timestamp: 0, value: 2 },
+          { timestamp: 10, value: 4 },
+          { timestamp: 20, value: 6 },
+        ],
+      },
+    ],
+  } as TimeSeriesQueryResult
+}
+
+describe("transformData", () => {
+  it("leaves gaps as nulls by default", () => {
+    const { chartData, seriesMeta } = transformData(makeResult())
+    expect(chartData).toHaveLength(3)
+    const keyA = seriesMeta[0].key
+    expect(chartData.map((row) => row[keyA])).toEqual([1, null, 3])
+  })
+
+  it("zero-fills gaps when zeroFillNulls is true (stacked-area mode)", () => {
+    const { chartData, seriesMeta } = transformData(makeResult(), {
+      zeroFillNulls: true,
+    })
+    const keyA = seriesMeta[0].key
+    const keyB = seriesMeta[1].key
+    expect(chartData.map((row) => row[keyA])).toEqual([1, 0, 3])
+    expect(chartData.map((row) => row[keyB])).toEqual([2, 4, 6])
+  })
+})

--- a/frontend/src/components/results/time-series/utils.ts
+++ b/frontend/src/components/results/time-series/utils.ts
@@ -52,19 +52,22 @@ export interface SeriesMeta {
 
 // Transforms backend series data into Recharts-compatible format
 // Each data point becomes a row with timestamp and values for each series
-// Missing data points are set to null so charts can show gaps
+// Missing data points are set to null by default (so line charts show gaps)
+// or to 0 when zeroFillNulls is true (required for stacked area to
+// avoid holes in the stack).
 //
 // Options:
 // - shortLegendLabels: use shorter labels (omit metric name) for when charts are split by metric
+// - zeroFillNulls: replace missing points with 0 instead of null
 export function transformData(
   result: TimeSeriesQueryResult,
-  options: { shortLegendLabels?: boolean } = {}
+  options: { shortLegendLabels?: boolean; zeroFillNulls?: boolean } = {}
 ): {
   chartData: Record<string, number | null>[]
   seriesMeta: SeriesMeta[]
 } {
   const { series, start_ms, end_ms, bucket_ms } = result
-  const { shortLegendLabels = false } = options
+  const { shortLegendLabels = false, zeroFillNulls = false } = options
 
   // Generate all bucket timestamps from start to end
   const timestamps: number[] = []
@@ -96,7 +99,7 @@ export function transformData(
     for (const { series: s, map } of seriesDataMaps) {
       const key = seriesKey(s.labels, s.name)
       const value = map.get(timestamp)
-      row[key] = value !== undefined ? value : null
+      row[key] = value !== undefined ? value : zeroFillNulls ? 0 : null
     }
 
     return row

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -93,10 +93,14 @@ export interface TableVisualization {
   displayed_fields?: string[]
 }
 
+export type TimeSeriesRenderAs = "line" | "stacked_area"
+
 export interface TimeSeriesVisualization {
   type: "time_series"
   bucket_ms?: number
   overlay?: boolean
+  // How to draw each series. Defaults to "line" when omitted.
+  render_as?: TimeSeriesRenderAs
 }
 
 export interface TraceVisualization {

--- a/skills/o11ylite/docs/events-query.md
+++ b/skills/o11ylite/docs/events-query.md
@@ -178,6 +178,10 @@ Bucketed time series. Requires at least one aggregation.
 
 `bucket_ms` is optional — auto-selected based on time range if omitted.
 
+Optional visualization fields:
+- `overlay` (boolean, default `false`) — when multiple metrics are present, draw them in a single chart instead of one chart per metric.
+- `render_as` (`"line"` | `"stacked_area"`, default `"line"`) — draw each series as a line, or as a filled region stacked on top of the others. Stacked area treats missing buckets as 0 so the stack has no holes; pick it for part-of-whole views (e.g. request count by status code).
+
 **Response:**
 ```json
 {


### PR DESCRIPTION
## Summary

Adds a `render_as` option to time-series visualizations so a chart can be drawn either as lines (the default) or as a stacked area — useful for part-of-whole views like "memory used by JVM pool", "requests by status code", or "CPU time by container".

**Schema.** `backend/src/o11ylite/store/{events,metrics}/query_schema.clj` gain an optional `:render_as` enum `["line" "stacked_area"]`. Frontend `TimeSeriesVisualization.render_as` mirrors it. Default is `"line"` so every existing chart and saved notebook/alert keeps rendering unchanged.

**UI.** `TimeSeriesChart` swaps from `<LineChart>` to Recharts' `<ComposedChart>`. It renders `<Area stackId="stack">` in stacked mode and keeps the existing `<Line>` path otherwise — zoom-drag, tooltip, legend, unit formatter, and ReferenceArea all carry over untouched. The settings popover gets a "Render as" dropdown alongside the existing "Overlay charts" switch.

**Nulls.** `transformData` gains a `zeroFillNulls` option. Stacked area turns it on so missing buckets become `0` rather than leaving holes in the stack; the line path keeps real `null` gaps so actual missing data stays visible.

**Docs.** `skills/o11ylite/docs/events-query.md` documents the new field so agents can set it when composing queries.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 16/16 pass (added `utils.test.ts` covering zero-fill)
- [x] `clojure -M:test/env:test/run --focus o11ylite.store.events.query-schema-test` — 11 tests / 152 assertions
- [x] `clojure -M:test/env:test/run --focus o11ylite.store.metrics.query-schema-test` — 11 tests / 71 assertions (added `visualization-validation-test`)
- [x] Manual verification on `dev/start` — picked `jvm.memory.used`, grouped by `attr.jvm.memory.pool.name`, switched render modes via the new settings dropdown, both rendered cleanly with real telemetry.

## Notes / follow-ups

- Negative series values under stacked area look odd (Recharts stacks them below the baseline). Not a regression since stacked mode is opt-in; can revisit if it bites.
- The default "Overlay off" path still works with stacked area — each per-metric sub-chart stacks its own series. Overlay + stacked gives a single stack across metrics, which is semantically weird but harmless.
