### PR TITLE
fix(time-series): disable animation on line render for consistency

### DIFF
--- a/frontend/src/components/results/time-series/time-series-chart.tsx
+++ b/frontend/src/components/results/time-series/time-series-chart.tsx
@@ -212,6 +212,7 @@ export function TimeSeriesChart({
                 strokeWidth={2}
                 dot={{ fill: series.color, strokeWidth: 0, r: 2 }}
                 connectNulls={connectNulls}
+                isAnimationActive={false}
               />
             )
           )}


### PR DESCRIPTION
## Summary

Small consistency fix on top of #78. Line and stacked-area shared a chart but had divergent animation settings — `<Line>` used Recharts' default entry animation while `<Area>` had it off. Standardize on **off** for both.

**Why no animation:** charts re-render constantly here (query runs, time-range scrubs, refresh, legend toggles, zoom-drag). High-cardinality group-by (e.g. 20+ JVM pools / containers / status codes) makes per-series fade-in feel laggy on Chrome. Grafana / Honeycomb / Datadog all render time-series tiles without entry animation for the same reasons.

Stroke widths stay different on purpose: line uses `strokeWidth={2}` (the line *is* the data), Area keeps `strokeWidth={1}` (the fill carries the visual weight, a thick outline on every band fights it).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 16/16 pass (no behaviour changes)
