### PR TITLE
fix(notebook): preserve URL (and time range) across cell mutations

### DIFF
--- a/frontend/src/components/notebook/add-cell-button.tsx
+++ b/frontend/src/components/notebook/add-cell-button.tsx
@@ -8,7 +8,7 @@ export function AddCellButton({ notebookId }: { notebookId: string }) {
     router.post(`/notebooks/${notebookId}/cells`, {
       query_mode: "events",
       query: { visualization: { type: "table" }, limit: 10 },
-    })
+    }, { preserveUrl: true })
   }
 
   return (

--- a/frontend/src/components/notebook/notebook-cell.tsx
+++ b/frontend/src/components/notebook/notebook-cell.tsx
@@ -97,6 +97,7 @@ export function NotebookCell({
     opts?: { onFinish?: () => void },
   ) => {
     router.put(cellUrl(notebookId, cell.id), payload, {
+      preserveUrl: true,
       onFinish: opts?.onFinish,
     })
   }
@@ -130,11 +131,11 @@ export function NotebookCell({
 
   const handleDelete = () => {
     if (!confirm("Delete this cell?")) return
-    router.delete(cellUrl(notebookId, cell.id))
+    router.delete(cellUrl(notebookId, cell.id), { preserveUrl: true })
   }
 
   const handleMove = (direction: "up" | "down") => {
-    router.post(`${cellUrl(notebookId, cell.id)}/move`, { direction })
+    router.post(`${cellUrl(notebookId, cell.id)}/move`, { direction }, { preserveUrl: true })
   }
 
   // ------------------------------------------------------------------


### PR DESCRIPTION
## Bug

Editing a notebook cell's query (e.g. in metric mode) resets the global time-range selector to `Last 15 minutes`, even if the user previously set it to something else like `Last 6 hours`.

## Root cause

Cell mutations go through Inertia (`router.put` / `router.post` / `router.delete`) and the backend responds with a 303 redirect to `/notebooks/:id` — **without the `?from=&to=` query string**. Inertia adopts that redirect target as the new page URL, so `window.location.search` loses `from`/`to`. `useTimeRange()` reads time range from URL params, so it falls back to the default `now-15m`.

This affects every cell mutation, not just metric query edits — the user just happened to notice it there. The same path is used by:

- `handleSaveQuery` (cell edit drawer save)
- `handleTogglePin` (pin/unpin)
- `handleVisualizationChange` (chart type / overlay toggle)
- `handleDelete`, `handleMove` (delete / reorder)
- `AddCellButton` (create new cell)

## Fix

Pass `preserveUrl: true` to every cell mutation so Inertia keeps the current browser URL across the redirect. The fix is local to the frontend — the backend redirect target stays as-is, which is fine because the URL is now ignored by the client.

`saveCell` is the single helper that wraps the four edit-related `router.put` calls in `notebook-cell.tsx`, so one change there covers them all.

## Verification

Reproduced the bug end-to-end against the dev stack with Playwright (notebook → set 6h → edit cell → save):

| step | URL search | time-range label |
|---|---|---|
| after `Last 6 hours` selected | `?from=now-6h&to=now` | Last 6 hours |
| after Save Cell (no fix) | _(empty)_ | **Last 15 minutes** ← bug |
| after Save Cell (with fix) | `?from=now-6h&to=now` | Last 6 hours ← fixed |

`npm test` (16 tests), `npm run lint`, and `tsc --noEmit` all pass.