### PR TITLE
feat(time-series): add 'bar' render mode

### DIFF
--- a/backend/src/o11ylite/store/events/query_schema.clj
+++ b/backend/src/o11ylite/store/events/query_schema.clj
@@ -134,7 +134,7 @@
    [:type [:= "time_series"]]
    [:bucket_ms {:optional true} [:int {:min 1}]]
    [:overlay {:optional true} :boolean]
-   [:render_as {:optional true} [:enum "line" "stacked_area"]]])
+   [:render_as {:optional true} [:enum "line" "stacked_area" "bar"]]])
 
 ;; DEFERRED: Heatmap visualization is deferred to post-v1.
 ;; Decision: Heatmap should be a "smart visualization" - when user selects heatmap,

--- a/backend/src/o11ylite/store/metrics/query_schema.clj
+++ b/backend/src/o11ylite/store/metrics/query_schema.clj
@@ -120,7 +120,7 @@
    [:type [:= "time_series"]]
    [:bucket_ms {:optional true} [:int {:min 1}]]
    [:overlay {:optional true} :boolean]
-   [:render_as {:optional true} [:enum "line" "stacked_area"]]])
+   [:render_as {:optional true} [:enum "line" "stacked_area" "bar"]]])
 
 (def visualization
   "Visualization config for metrics queries. Currently only time_series is supported."

--- a/backend/test/o11ylite/store/events/query_schema_test.clj
+++ b/backend/test/o11ylite/store/events/query_schema_test.clj
@@ -92,6 +92,9 @@
     (is (valid? {:time_range {:start 1702000000000 :end 1702003600000}
                  :aggregations [{:id "A" :field "*" :function "count"}]
                  :visualization {:type "time_series" :render_as "stacked_area"}}))
+    (is (valid? {:time_range {:start 1702000000000 :end 1702003600000}
+                 :aggregations [{:id "A" :field "*" :function "count"}]
+                 :visualization {:type "time_series" :render_as "bar"}}))
     (is (invalid? {:time_range {:start 1702000000000 :end 1702003600000}
                    :aggregations [{:id "A" :field "*" :function "count"}]
                    :visualization {:type "time_series" :render_as "pie"}})))

--- a/backend/test/o11ylite/store/metrics/query_schema_test.clj
+++ b/backend/test/o11ylite/store/metrics/query_schema_test.clj
@@ -238,18 +238,21 @@
     (is (valid? {:time_range {:start 1702000000000 :end 1702003600000}
                  :metrics [{:id "A" :name "cpu.utilization" :agg "avg"}]})))
 
-  (testing "render_as enum accepts line and stacked_area"
+  (testing "render_as enum accepts line, stacked_area, and bar"
     (is (valid? {:time_range {:start 1702000000000 :end 1702003600000}
                  :metrics [{:id "A" :name "cpu.utilization" :agg "avg"}]
                  :visualization {:type "time_series" :render_as "line"}}))
     (is (valid? {:time_range {:start 1702000000000 :end 1702003600000}
                  :metrics [{:id "A" :name "cpu.utilization" :agg "avg"}]
-                 :visualization {:type "time_series" :render_as "stacked_area"}})))
+                 :visualization {:type "time_series" :render_as "stacked_area"}}))
+    (is (valid? {:time_range {:start 1702000000000 :end 1702003600000}
+                 :metrics [{:id "A" :name "cpu.utilization" :agg "avg"}]
+                 :visualization {:type "time_series" :render_as "bar"}})))
 
   (testing "render_as rejects unknown values"
     (is (invalid? {:time_range {:start 1702000000000 :end 1702003600000}
                    :metrics [{:id "A" :name "cpu.utilization" :agg "avg"}]
-                   :visualization {:type "time_series" :render_as "bar"}}))))
+                   :visualization {:type "time_series" :render_as "pie"}}))))
 
 ;; ---------------------------------------------------------
 ;; Full Query Examples

--- a/frontend/src/components/results/time-series/time-series-chart.tsx
+++ b/frontend/src/components/results/time-series/time-series-chart.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useCallback, useRef } from "react"
-import { Area, CartesianGrid, ComposedChart, Line, XAxis, YAxis, ReferenceArea } from "recharts"
+import { Area, Bar, CartesianGrid, ComposedChart, Line, XAxis, YAxis, ReferenceArea } from "recharts"
 
 import type { TimeSeriesQueryResult, TimeSeriesRenderAs } from "@/types"
 import { useTimeRange } from "@/hooks/use-time-range"
@@ -38,13 +38,15 @@ export function TimeSeriesChart({
   units,
   renderAs = "line",
 }: TimeSeriesChartProps) {
-  // Stacked area requires numeric values at every bucket -- otherwise the stack
-  // develops holes. Zero-fill missing points only for the stacked path; the
-  // line path keeps nulls so real gaps remain visible.
+  // Stacked area and stacked bars both require numeric values at every bucket --
+  // otherwise the stack develops holes. Zero-fill missing points only for those
+  // paths; the line path keeps nulls so real gaps remain visible.
   const isStackedArea = renderAs === "stacked_area"
+  const isBar = renderAs === "bar"
+  const zeroFillNulls = isStackedArea || isBar
   const { chartData, seriesMeta } = useMemo(
-    () => transformData(data, { shortLegendLabels, zeroFillNulls: isStackedArea }),
-    [data, shortLegendLabels, isStackedArea]
+    () => transformData(data, { shortLegendLabels, zeroFillNulls }),
+    [data, shortLegendLabels, zeroFillNulls]
   )
   const showLegend = seriesMeta.length > 1
   const { setRange } = useTimeRange()
@@ -186,24 +188,39 @@ export function TimeSeriesChart({
             }
           />
           {showLegend && <ChartLegend content={<ChartLegendContent />} />}
-          {seriesMeta.map((series) =>
-            isStackedArea ? (
-              <Area
-                key={series.key}
-                dataKey={series.key}
-                type="monotone"
-                stackId="stack"
-                stroke={series.color}
-                strokeWidth={1}
-                fill={series.color}
-                fillOpacity={0.4}
-                // Stacked areas are already zero-filled in transformData, so
-                // connectNulls has no effect -- pass true for safety.
-                connectNulls
-                isAnimationActive={false}
-                activeDot={{ r: 3 }}
-              />
-            ) : (
+          {seriesMeta.map((series) => {
+            if (isStackedArea) {
+              return (
+                <Area
+                  key={series.key}
+                  dataKey={series.key}
+                  type="monotone"
+                  stackId="stack"
+                  stroke={series.color}
+                  strokeWidth={1}
+                  fill={series.color}
+                  fillOpacity={0.4}
+                  // Stacked areas are already zero-filled in transformData, so
+                  // connectNulls has no effect -- pass true for safety.
+                  connectNulls
+                  isAnimationActive={false}
+                  activeDot={{ r: 3 }}
+                />
+              )
+            }
+            if (isBar) {
+              return (
+                <Bar
+                  key={series.key}
+                  dataKey={series.key}
+                  stackId="stack"
+                  fill={series.color}
+                  fillOpacity={0.85}
+                  isAnimationActive={false}
+                />
+              )
+            }
+            return (
               <Line
                 key={series.key}
                 dataKey={series.key}
@@ -215,7 +232,7 @@ export function TimeSeriesChart({
                 isAnimationActive={false}
               />
             )
-          )}
+          })}
           {refAreaLeft !== null && refAreaRight !== null && (
             <ReferenceArea
               x1={refAreaLeft}

--- a/frontend/src/components/results/time-series/time-series-settings.tsx
+++ b/frontend/src/components/results/time-series/time-series-settings.tsx
@@ -55,6 +55,7 @@ export function TimeSeriesSettings({
               <SelectContent>
                 <SelectItem value="line">Lines</SelectItem>
                 <SelectItem value="stacked_area">Stacked area</SelectItem>
+                <SelectItem value="bar">Bar</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -93,7 +93,7 @@ export interface TableVisualization {
   displayed_fields?: string[]
 }
 
-export type TimeSeriesRenderAs = "line" | "stacked_area"
+export type TimeSeriesRenderAs = "line" | "stacked_area" | "bar"
 
 export interface TimeSeriesVisualization {
   type: "time_series"

--- a/skills/o11ylite/docs/events-query.md
+++ b/skills/o11ylite/docs/events-query.md
@@ -180,7 +180,7 @@ Bucketed time series. Requires at least one aggregation.
 
 Optional visualization fields:
 - `overlay` (boolean, default `false`) — when multiple metrics are present, draw them in a single chart instead of one chart per metric.
-- `render_as` (`"line"` | `"stacked_area"`, default `"line"`) — draw each series as a line, or as a filled region stacked on top of the others. Stacked area treats missing buckets as 0 so the stack has no holes; pick it for part-of-whole views (e.g. request count by status code).
+- `render_as` (`"line"` | `"stacked_area"` | `"bar"`, default `"line"`) — draw each series as a line, as a filled region stacked on top of the others, or as a stacked bar per bucket. Stacked area and bar treat missing buckets as 0 so the stack has no holes; pick either for part-of-whole views (e.g. request count by status code).
 
 **Response:**
 ```json


### PR DESCRIPTION
## Summary

Adds a `"bar"` option to the `render_as` enum introduced in #78. Bars stack per bucket — same `stackId` as the stacked-area path — so a part-of-whole view is available with discrete buckets emphasised over trends. Default is still `"line"`, so existing charts and saved notebooks/alerts are unchanged.

**Schema.** `backend/src/o11ylite/store/{events,metrics}/query_schema.clj` extend the optional `:render_as` enum to `["line" "stacked_area" "bar"]`. Frontend `TimeSeriesRenderAs` mirrors it.

**UI.** `TimeSeriesChart` adds a `<Bar stackId="stack">` branch alongside the existing line / stacked-area branches in the same `<ComposedChart>`. Tooltip, legend, zoom-drag, unit formatter and ReferenceArea all carry over untouched. The settings popover gains a third `"Bar"` entry in the **Render as** select.

**Nulls.** The `zeroFillNulls` option from #78 is now applied to both stacked area and bar mode (any stacked path), so missing buckets render as zero-height segments rather than leaving holes in the stack.

**Docs.** `skills/o11ylite/docs/events-query.md` lists `"bar"` as a valid value.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 16/16 pass (existing zero-fill coverage applies to bar mode)
- [x] `(run-tests 'o11ylite.store.events.query-schema-test)` — 11 tests / 153 assertions
- [x] `(run-tests 'o11ylite.store.metrics.query-schema-test)` — 11 tests / 72 assertions
- [x] Manual verification on `dev/start` — picked `jvm.memory.used` summed by `attr.jvm.memory.pool.name`, switched to **Bar** in the settings popover, real telemetry rendered as a stacked bar chart with all 8 JVM memory pools.

## Notes

- Negative series under bar mode stack below the baseline (same caveat as stacked area). Opt-in only, so not a regression.
- Overlay + bar gives a single stack across metrics — semantically odd if units differ, but harmless and consistent with how overlay + stacked area behaves.
