### PR TITLE
fix(time-series): stable colors via sorted series keys

### DIFF
--- a/frontend/src/components/results/time-series/utils.test.ts
+++ b/frontend/src/components/results/time-series/utils.test.ts
@@ -49,4 +49,24 @@ describe("transformData", () => {
     expect(chartData.map((row) => row[keyA])).toEqual([1, 0, 3])
     expect(chartData.map((row) => row[keyB])).toEqual([2, 4, 6])
   })
+
+  it("assigns colors deterministically from sorted series keys, independent of input order", () => {
+    // Capture the (key → color) mapping in the natural input order.
+    const { seriesMeta } = transformData(makeResult())
+    const colorByKey = new Map(seriesMeta.map((m) => [m.key, m.color]))
+
+    // The lowest-sorting key should get the first palette slot. This is the
+    // guarantee that lets us use the most distinct colors first.
+    const sortedKeys = [...colorByKey.keys()].sort()
+    expect(colorByKey.get(sortedKeys[0])).toBe("var(--chart-1)")
+
+    // Reversing the series order in the response must not change any series'
+    // color -- this is the bug the fix prevents.
+    const reversed = makeResult()
+    reversed.series = [...reversed.series].reverse()
+    const { seriesMeta: reversedMeta } = transformData(reversed)
+    for (const meta of reversedMeta) {
+      expect(meta.color).toBe(colorByKey.get(meta.key))
+    }
+  })
 })

--- a/frontend/src/components/results/time-series/utils.ts
+++ b/frontend/src/components/results/time-series/utils.ts
@@ -1,6 +1,8 @@
 import type { TimeSeriesQueryResult } from "@/types"
 
-// Chart color palette - cycles through these for multiple series
+// Chart color palette - series are assigned colors from this list in order
+// of their sorted seriesKey, so the same set of series always produces the
+// same color mapping regardless of how the backend ordered them.
 const CHART_COLORS = [
   "var(--chart-1)",
   "var(--chart-2)",
@@ -75,13 +77,25 @@ export function transformData(
     timestamps.push(ts)
   }
 
-  // Build series metadata
+  // Build series metadata.
+  // Color assignment: sort the series' stable keys and pick colors from the
+  // palette in that order. This guarantees the same set of series always
+  // produces the same color mapping (no reshuffling on refresh) and uses the
+  // earlier (more distinct) palette slots first.
   const labelFn = shortLegendLabels ? seriesLegendLabel : seriesLabel
-  const seriesMeta = series.map((s, idx) => ({
-    key: seriesKey(s.labels, s.name),
-    label: labelFn(s.labels, s.name),
-    color: CHART_COLORS[idx % CHART_COLORS.length],
-  }))
+  const keys = series.map((s) => seriesKey(s.labels, s.name))
+  const sortedKeys = [...keys].sort()
+  const colorByKey = new Map(
+    sortedKeys.map((k, i) => [k, CHART_COLORS[i % CHART_COLORS.length]])
+  )
+  const seriesMeta = series.map((s, i) => {
+    const key = keys[i]
+    return {
+      key,
+      label: labelFn(s.labels, s.name),
+      color: colorByKey.get(key)!,
+    }
+  })
 
   // Index series data by timestamp for O(1) lookup
   const seriesDataMaps = series.map((s) => {


### PR DESCRIPTION
## Summary

**Bug.** Refreshing the page (or re-running the same query) sometimes reshuffles the colors on a time-series chart — group A might be blue one moment and yellow the next. Confusing in any monitoring context.

**Root cause.** `transformData` in `frontend/src/components/results/time-series/utils.ts` assigned a color by array index:

```ts
color: CHART_COLORS[idx % CHART_COLORS.length]
```

The metrics backend builds series with Clojure's `group-by`, whose output is an unordered hash map. The same query can return its series in different orders across calls, and the index-based scheme means every series shifts to a new color slot whenever that happens. The events backend has the same property.

**Fix.** Sort the series' stable `seriesKey` alphabetically before assigning colors from the palette. Same set of series → same sort → same color mapping. Critically, this also means **the most distinct palette slots (chart-1, -2, -3, …) are always used first**, instead of randomly landing on chart-7 with collisions.

```ts
const keys = series.map((s) => seriesKey(s.labels, s.name))
const sortedKeys = [...keys].sort()
const colorByKey = new Map(sortedKeys.map((k, i) => [k, CHART_COLORS[i % CHART_COLORS.length]]))
```

## Trade-off vs. hash-based pinning

A hash-based scheme would pin a given series to the same color forever, even if other series come and go. Sort-based pins the mapping for a given **set** of series — adding or removing a series can shift colors within the set if the new entry sorts before existing ones.

Picking sort because:
1. The reported pain point is "I refreshed and everything is different" — sort fixes it.
2. Hash routinely lands series on chart-7+ and creates collisions in the same render. Sort always uses the prettiest slots first.
3. Changing your query is a deliberate action where re-coloring is unsurprising; a passive refresh shouldn't change anything.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 17/17 pass; new test directly guards both invariants:
  - the lowest-sorting key gets `var(--chart-1)`
  - reversing the input order leaves every series' color unchanged
- [x] Manual on `dev/start`: same JVM-memory-pool query opened in two fresh tabs produced identical pool→color mappings end-to-end (verified by reading every legend swatch's computed `backgroundColor` from the DOM). The lowest-sorting pool (`CodeHeap 'non-nmethods'`) got `--chart-1` as expected.

## Notes / follow-ups

- If you ever care about pinning identity across query edits (e.g. saved dashboards where a series should keep its color even after you tweak a filter), a hash-based or per-saved-query persisted mapping would be the next step. Out of scope here.
