### PR TITLE
feat(metrics): add formula support to /api/query/metrics

### DIFF
--- a/backend/src/o11ylite/store/metrics/formula.clj
+++ b/backend/src/o11ylite/store/metrics/formula.clj
@@ -1,0 +1,236 @@
+;; ---------------------------------------------------------
+;; o11ylite.store.metrics.formula
+;;
+;; Tiny expression language for metric formulas.
+;; Supports +, -, *, /, parentheses, unary minus over numeric literals
+;; and single-letter metric refs (A-Z). Pure functions; no I/O.
+;;
+;; AST shape:
+;;   [:num d] | [:ref "A"] | [:+ a b] | [:- a b] | [:* a b] | [:/ a b]
+;; ---------------------------------------------------------
+
+(ns o11ylite.store.metrics.formula
+  (:require
+    [clojure.set :as set]
+    [clojure.string :as str]))
+
+;; ---------------------------------------------------------
+;; Tokenizer
+
+(defn- -tokenize
+  "Lex a formula string into tokens.
+   Token shapes: [:num x] | [:ref \"A\"] | [:op \"+\"] | [:lparen] | [:rparen]"
+  [^String s]
+  (loop [i 0, out []]
+    (if (>= i (count s))
+      out
+      (let [c (.charAt s i)]
+        (cond
+          (Character/isWhitespace c)  (recur (inc i) out)
+          (= c \()                    (recur (inc i) (conj out [:lparen]))
+          (= c \))                    (recur (inc i) (conj out [:rparen]))
+          (#{\+ \- \* \/} c)          (recur (inc i) (conj out [:op (str c)]))
+          (Character/isDigit c)
+          (let [m (re-find #"^\d+(?:\.\d+)?" (subs s i))]
+            (recur (+ i (count m)) (conj out [:num (Double/parseDouble m)])))
+          (and (Character/isLetter c) (Character/isUpperCase c))
+          ;; Single-letter ref. If the next char is also a letter/digit,
+          ;; that's a multi-char identifier — reject.
+          (let [j (inc i)]
+            (when (and (< j (count s))
+                       (Character/isLetterOrDigit (.charAt s j)))
+              (throw (ex-info (str "Invalid identifier at pos " i)
+                              {:pos i :char c})))
+            (recur j (conj out [:ref (str c)])))
+          :else
+          (throw (ex-info (str "Unexpected char '" c "' at pos " i)
+                          {:pos i :char c})))))))
+
+;; ---------------------------------------------------------
+;; Pratt parser
+
+(def ^:private -binop-prec
+  {"+" 10 "-" 10 "*" 20 "/" 20})
+
+(declare -parse-expr)
+
+(defn- -parse-primary
+  [tokens]
+  (let [[t & more] tokens]
+    (case (first t)
+      :num    [[:num (second t)] more]
+      :ref    [[:ref (second t)] more]
+      :lparen (let [[expr rest1] (-parse-expr more 0)]
+                (when-not (= [:rparen] (first rest1))
+                  (throw (ex-info "Expected ')'" {})))
+                [expr (next rest1)])
+      :op     (if (= "-" (second t))
+                ;; Unary minus. Constant-fold when operand is a literal so
+                ;; "-2" parses to [:num -2.0]; otherwise rewrite as 0 - expr.
+                (let [[expr rest1] (-parse-primary more)]
+                  (if (and (vector? expr) (= :num (first expr)))
+                    [[:num (- (second expr))] rest1]
+                    [[:- [:num 0.0] expr] rest1]))
+                (throw (ex-info (str "Unexpected operator " (second t)) {})))
+      (throw (ex-info "Unexpected end of expression"
+                      {:remaining tokens})))))
+
+(defn- -parse-expr
+  [tokens min-prec]
+  (loop [[lhs tokens] (-parse-primary tokens)]
+    (let [[t] tokens
+          op (when (= :op (first t)) (second t))
+          prec (some-> op -binop-prec)]
+      (if (and prec (>= prec min-prec))
+        (let [[rhs rest1] (-parse-expr (next tokens) (inc prec))]
+          (recur [[(keyword op) lhs rhs] rest1]))
+        [lhs tokens]))))
+
+(defn parse
+  "Parse a formula string into an AST.
+   AST shape: [:num d] | [:ref \"A\"] | [:+ a b] | [:- a b] | [:* a b] | [:/ a b]
+   Throws ex-info on parse error."
+  [s]
+  (when (str/blank? s)
+    (throw (ex-info "Empty formula" {})))
+  (let [tokens (-tokenize s)
+        [expr leftover] (-parse-expr tokens 0)]
+    (when (seq leftover)
+      (throw (ex-info "Unexpected trailing tokens"
+                      {:leftover leftover})))
+    expr))
+
+;; ---------------------------------------------------------
+;; Ref extraction
+
+(defn refs
+  "Return distinct metric refs in AST in order of first appearance."
+  [ast]
+  (let [seen (volatile! #{})
+        order (volatile! [])
+        walk (fn walk [node]
+               (case (first node)
+                 :num nil
+                 :ref (let [r (second node)]
+                        (when-not (@seen r)
+                          (vswap! seen conj r)
+                          (vswap! order conj r)))
+                 (do (walk (nth node 1))
+                     (walk (nth node 2)))))]
+    (walk ast)
+    @order))
+
+;; ---------------------------------------------------------
+;; Evaluator (single bucket)
+
+(defn eval-ast
+  "Evaluate AST against a {ref => number-or-nil} env.
+   Returns nil if any input is nil or if division by zero occurs."
+  [ast env]
+  (case (first ast)
+    :num (second ast)
+    :ref (get env (second ast))
+    (let [a (eval-ast (nth ast 1) env)
+          b (eval-ast (nth ast 2) env)]
+      (cond
+        (or (nil? a) (nil? b)) nil
+        (and (= :/ (first ast)) (zero? b)) nil
+        :else (case (first ast)
+                :+ (+ a b)
+                :- (- a b)
+                :* (* a b)
+                :/ (/ a b))))))
+
+;; ---------------------------------------------------------
+;; Series merge — inner join on (bucket, labels)
+
+(defn- -index-by-id
+  "Group series by metric id => seq of series."
+  [series]
+  (group-by :id series))
+
+(defn- -bucket-map
+  "Convert one series's :data into {timestamp => value}."
+  [s]
+  (into {} (map (juxt :timestamp :value)) (:data s)))
+
+(defn- -join-series-by-labels
+  "For each unique :labels combination, return {ref => series} where
+   every required ref has a series with that label set.
+   Series without all required refs are skipped."
+  [series-by-id required-refs]
+  (when (every? series-by-id required-refs)
+    (let [;; All label sets that appear under each required ref
+          label-sets-per-ref (mapv #(set (map :labels (series-by-id %)))
+                                   required-refs)
+          ;; Inner-join across all refs
+          common-labels (reduce set/intersection label-sets-per-ref)]
+      (for [labels common-labels]
+        {:labels labels
+         :series-by-ref
+         (into {}
+               (for [r required-refs]
+                 [r (first (filter #(= labels (:labels %))
+                                   (series-by-id r)))]))}))))
+
+(defn- -evaluate-formula
+  "Evaluate one formula across joined series, returning synthetic
+   series (zero or more)."
+  [series-by-id {:keys [id expr name unit]}]
+  (let [ast (parse expr)
+        required (refs ast)]
+    (for [{:keys [labels series-by-ref]}
+          (-join-series-by-labels series-by-id required)
+          :let [bucket-maps (into {}
+                                  (map (fn [[r s]] [r (-bucket-map s)]))
+                                  series-by-ref)
+                ;; Inner-join on timestamps: only buckets present in
+                ;; *every* operand survive.
+                common-buckets (sort (reduce
+                                       set/intersection
+                                       (map #(set (keys %))
+                                            (vals bucket-maps))))
+                points (keep
+                         (fn [t]
+                           (let [env (into {}
+                                           (map (fn [[r m]] [r (get m t)]))
+                                           bucket-maps)
+                                 v (eval-ast ast env)]
+                             (when (some? v) {:timestamp t :value v})))
+                         common-buckets)]
+          :when (seq points)]
+      (cond-> {:id id
+               :name (if name (str id ": " name) id)
+               :metric nil
+               :formula expr
+               :labels labels
+               :data (vec points)}
+        unit (assoc :unit unit)))))
+
+(defn apply-formulas
+  "Append one synthetic series per (formula × matching label combo) to
+   the input series. Source series are returned unchanged.
+   `formulas` is a vector of {:id :expr :name? :unit?}."
+  [series formulas]
+  (let [series-by-id (-index-by-id series)]
+    (vec (concat series
+                 (mapcat #(-evaluate-formula series-by-id %) formulas)))))
+
+;; ---------------------------------------------------------
+;; Rich Comment
+(comment
+
+  ;; Parse a simple ratio expression
+  (parse "A / B * 100")
+  ;; => [:* [:/ [:ref "A"] [:ref "B"]] [:num 100.0]]
+
+  ;; Unary minus on a literal folds to a single :num node
+  (parse "-2")
+  ;; => [:num -2.0]
+
+  ;; Extract referenced metric ids in order of first appearance
+  (refs (parse "(A - B) / A * 100"))
+  ;; => ["A" "B"]
+
+  #_()) ; End of rich comment block
+;; ---------------------------------------------------------

--- a/backend/src/o11ylite/store/metrics/query.clj
+++ b/backend/src/o11ylite/store/metrics/query.clj
@@ -14,9 +14,9 @@
 ;;   - Global filters + per-metric filters
 ;;   - Shared group-by across metrics
 ;;   - Auto or manual time bucketing
+;;   - Optional formulas computed over the resulting series (A / B * 100)
 ;;
 ;; Deferred:
-;;   - Formula support (A / B * 100)
 ;;   - Histogram percentiles (p50, p99)
 ;; ---------------------------------------------------------
 
@@ -24,6 +24,7 @@
   (:require
     [honey.sql :as sql]
     [next.jdbc :as jdbc]
+    [o11ylite.store.metrics.formula :as formula]
     [o11ylite.store.metrics.metadata :as metadata]
     [o11ylite.store.metrics.query-schema :as query-schema]
     [o11ylite.store.metrics.query-validation :as query-validation]
@@ -213,8 +214,13 @@
                        :name \"avg(cpu.utilization)\"
                        :labels {:attr.host.name \"server-1\"}
                        :data [{:timestamp N :value N} ...]}
+                      ;; If :formulas were supplied, synthetic series are
+                      ;; appended after metric series. They carry :id (e.g.
+                      ;; \"F1\"), :metric nil, :formula <expr>, :name (\"F1\"
+                      ;; or \"F1: <user-name>\"), and a (possibly :unit) field.
                       ...]
              :units {\"cpu.utilization\" \"%\"
+                     ;; Formula units appear keyed as \"F1\" or \"F1: name\"
                      \"network.io\" \"By\"}}
       :metadata {:query_time_ms N}}"
   [duckdb sqlite query]
@@ -226,10 +232,18 @@
         end-ms (query-util/align-to-bucket (:end time_range) resolved-bucket-ms)
         ;; Execute query for each metric, collecting series and units
         results (map #(-execute-metric duckdb sqlite query % resolved-bucket-ms) metrics)
-        all-series (vec (mapcat :series results))
-        units (into {} (map (fn [metric result]
-                              [(:name metric) (:unit result)])
-                            metrics results))
+        raw-series (vec (mapcat :series results))
+        formulas (or (:formulas query) [])
+        ;; Append synthetic formula series (one per formula × matching label combo)
+        all-series (formula/apply-formulas raw-series formulas)
+        metric-units (into {} (map (fn [metric result]
+                                     [(:name metric) (:unit result)])
+                                   metrics results))
+        formula-units (into {} (for [f formulas
+                                     :when (:unit f)]
+                                 [(if (:name f) (str (:id f) ": " (:name f)) (:id f))
+                                  (:unit f)]))
+        units (merge metric-units formula-units)
         query-time-ms (- (System/currentTimeMillis) start-time)]
     {:data {:bucket_ms resolved-bucket-ms
             :start_ms start-ms

--- a/backend/src/o11ylite/store/metrics/query_schema.clj
+++ b/backend/src/o11ylite/store/metrics/query_schema.clj
@@ -9,9 +9,9 @@
 ;;   - Top-level filter + per-metric filter overrides
 ;;   - Shared group-by across all metrics
 ;;   - Auto or manual time bucketing
+;;   - Formula support (A / B * 100) with cross-field validation
 ;;
 ;; Deferred:
-;;   - Formula support (A / B * 100)
 ;;   - Aggregation-type validation (requires metadata lookup)
 ;;   - Histogram percentiles (p50, p99)
 ;; ---------------------------------------------------------
@@ -19,7 +19,8 @@
 (ns o11ylite.store.metrics.query-schema
   (:require
     [malli.core :as m]
-    [malli.error :as me]))
+    [malli.error :as me]
+    [o11ylite.store.metrics.formula :as formula]))
 
 ;; ---------------------------------------------------------
 ;; Primitive Schemas
@@ -70,7 +71,7 @@
 ;; Metric-Specific Schemas
 
 (def metric-ref
-  "Single uppercase letter A-Z for referencing metrics in formulas (future)."
+  "Single uppercase letter A-Z for referencing metrics in formulas."
   [:re {:error/message "metric id must be a single uppercase letter A-Z"}
    #"^[A-Z]$"])
 
@@ -96,6 +97,20 @@
    [:name metric-name]
    [:agg aggregation]
    [:filter {:optional true} filter-expr]])
+
+(def formula-ref
+  "Formula identifier. Distinct from metric-ref namespace (A-Z) — uses
+   F1-F9 to make formula vs metric IDs visually unambiguous."
+  [:re {:error/message "formula id must be F1-F9"}
+   #"^F[1-9]$"])
+
+(def formula-definition
+  "Definition of a single formula computed over metric query results."
+  [:map
+   [:id formula-ref]
+   [:expr [:string {:min 1 :max 256}]]
+   [:name {:optional true} [:string {:min 1 :max 128}]]
+   [:unit {:optional true} [:string {:max 32}]]])
 
 ;; ---------------------------------------------------------
 ;; Having Schema
@@ -138,6 +153,7 @@
    [:group_by {:optional true} [:vector field-name]]
    [:having {:optional true} having-expr]
    [:metrics [:vector {:min 1} metric-definition]]
+   [:formulas {:optional true} [:vector {:max 10} formula-definition]]
    [:visualization {:optional true} visualization]])
 
 (defn- -unique-metric-ids?
@@ -154,6 +170,42 @@
       (contains? metric-ids (:ref having)))
     true))
 
+(defn- -unique-formula-ids?
+  "All formula IDs must be unique within :formulas."
+  [{:keys [formulas]}]
+  (let [ids (map :id formulas)]
+    (= (count ids) (count (set ids)))))
+
+(defn- -formulas-parse?
+  "Every formula :expr must parse successfully."
+  [{:keys [formulas]}]
+  (every? (fn [{:keys [expr]}]
+            (try
+              (formula/parse expr)
+              true
+              (catch Exception _ false)))
+          formulas))
+
+(defn- -formula-refs-resolve?
+  "Every metric ref inside a formula :expr must exist in :metrics."
+  [{:keys [formulas metrics]}]
+  (let [metric-ids (set (map :id metrics))]
+    (every?
+      (fn [{:keys [expr]}]
+        (try
+          (every? metric-ids (formula/refs (formula/parse expr)))
+          (catch Exception _ true)))   ; parse failure reported by -formulas-parse?
+      formulas)))
+
+(defn- -formula-has-refs?
+  "Every formula must reference at least one metric (no constant-only exprs)."
+  [{:keys [formulas]}]
+  (every? (fn [{:keys [expr]}]
+            (try
+              (seq (formula/refs (formula/parse expr)))
+              (catch Exception _ true)))   ; parse failure reported by -formulas-parse?
+          formulas))
+
 (def metrics-query
   "Schema for metrics query requests."
   [:and
@@ -161,7 +213,15 @@
    [:fn {:error/message "metric IDs must be unique"}
     -unique-metric-ids?]
    [:fn {:error/message "having ref must reference an existing metric ID"}
-    -valid-having-ref?]])
+    -valid-having-ref?]
+   [:fn {:error/message "formula IDs must be unique"}
+    -unique-formula-ids?]
+   [:fn {:error/message "formula expressions must be valid"}
+    -formulas-parse?]
+   [:fn {:error/message "formula refs must reference declared metric IDs"}
+    -formula-refs-resolve?]
+   [:fn {:error/message "formula must reference at least one metric"}
+    -formula-has-refs?]])
 
 ;; ---------------------------------------------------------
 ;; Validation
@@ -207,6 +267,17 @@
                          :name "http.server.requests"
                          :agg "sum"}]
               :group_by ["attr.service"]})
+  ;; => nil
+
+  ;; Valid query with formula (free memory %)
+  (validate metrics-query
+            {:time_range {:start 1702000000000 :end 1702003600000}
+             :metrics [{:id "A" :name "mem.free" :agg "avg"}
+                       {:id "B" :name "mem.total" :agg "avg"}]
+             :formulas [{:id "F1"
+                         :expr "A / B * 100"
+                         :name "free mem %"
+                         :unit "%"}]})
   ;; => nil
 
   ;; Missing time_range

--- a/backend/test/o11ylite/integration/api/metric_query_test.clj
+++ b/backend/test/o11ylite/integration/api/metric_query_test.clj
@@ -784,3 +784,79 @@
         (let [data-points (:data (first series))]
           (is (= 1 (count data-points)))
           (is (= 90.0 (:value (first data-points)))))))))
+
+;; ---------------------------------------------------------
+;; Formulas
+
+(deftest metrics-query-formula-test
+  (testing "POST /api/query/metrics returns formula series alongside source series"
+    (let [bucket-time (-> (t/instant) (t/truncate :minutes))
+          bucket-ms (.toEpochMilli bucket-time)
+          time-ns (instant->time-ns bucket-time)
+          end-ms (+ bucket-ms 60000)]
+
+      ;; Ingest two gauge metrics at the same bucket
+      (h/export-metrics!
+        {:service-name "formula-test-service"
+         :meter-name "test-meter"
+         :metrics [(h/build-gauge-metric
+                     {:name "test.mem.free"
+                      :unit "By"
+                      :data-points [{:value 900.0 :time-ns time-ns}]})
+                   (h/build-gauge-metric
+                     {:name "test.mem.total"
+                      :unit "By"
+                      :data-points [{:value 1000.0 :time-ns time-ns}]})]})
+
+      (let [response (h/post-json "/api/query/metrics"
+                                  {:time_range {:start bucket-ms :end end-ms}
+                                   :bucket_ms 60000
+                                   :metrics [{:id "A" :name "test.mem.free" :agg "last"}
+                                             {:id "B" :name "test.mem.total" :agg "last"}]
+                                   :formulas [{:id "F1"
+                                               :expr "A / B * 100"
+                                               :name "free mem %"
+                                               :unit "%"}]})
+            series (get-in response [:body :data :series])
+            ids (set (map :id series))
+            f1 (first (filter #(= "F1" (:id %)) series))
+            units (get-in response [:body :data :units])]
+        (is (= 200 (h/status response)))
+        ;; Source series A and B preserved, plus formula F1
+        (is (= #{"A" "B" "F1"} ids))
+        (is (some? f1))
+        (is (= "F1: free mem %" (:name f1)))
+        (is (= "A / B * 100" (:formula f1)))
+        (is (nil? (:metric f1)))
+        ;; A=900, B=1000 -> A/B*100 = 90.0
+        (let [point (-> f1 :data first)]
+          (is (some? point))
+          (is (<= 89.9 (:value point) 90.1)))
+        ;; Unit propagated (JSON-roundtripped: string keys become keywords)
+        (is (= "%" (get units (keyword "F1: free mem %")))))))
+
+  (testing "POST /api/query/metrics with no matching label combos returns no formula series"
+    ;; Request a formula but ingest only one of the two referenced metrics.
+    ;; This is a sanity check that the endpoint doesn't crash; no F1 series expected.
+    (let [bucket-time (-> (t/instant) (t/truncate :minutes))
+          bucket-ms (.toEpochMilli bucket-time)
+          time-ns (instant->time-ns bucket-time)
+          end-ms (+ bucket-ms 60000)]
+      (h/export-metrics!
+        {:service-name "formula-test-service-2"
+         :meter-name "test-meter"
+         :metrics [(h/build-gauge-metric
+                     {:name "test.solo.metric"
+                      :unit "%"
+                      :data-points [{:value 50.0 :time-ns time-ns}]})]})
+      (let [response (h/post-json "/api/query/metrics"
+                                  {:time_range {:start bucket-ms :end end-ms}
+                                   :bucket_ms 60000
+                                   :metrics [{:id "A" :name "test.solo.metric" :agg "last"}
+                                             {:id "B" :name "test.absent.metric" :agg "last"}]
+                                   :formulas [{:id "F1" :expr "A / B"}]})
+            series (get-in response [:body :data :series])
+            f1-series (filter #(= "F1" (:id %)) series)]
+        (is (= 200 (h/status response)))
+        ;; A series present, B series empty/absent, F1 not emitted
+        (is (empty? f1-series))))))

--- a/backend/test/o11ylite/store/metrics/formula_test.clj
+++ b/backend/test/o11ylite/store/metrics/formula_test.clj
@@ -1,0 +1,165 @@
+;; ---------------------------------------------------------
+;; o11ylite.store.metrics.formula-test
+;;
+;; Unit tests for the metric formula parser, evaluator, and apply-formulas.
+;; Covers tokenize -> parse -> AST, ref extraction, single-bucket eval,
+;; and series-level inner-join on labels and timestamps.
+;; ---------------------------------------------------------
+
+(ns o11ylite.store.metrics.formula-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [o11ylite.store.metrics.formula :as formula]))
+
+(deftest parse-test
+  (testing "literals"
+    (is (= [:num 1.0]   (formula/parse "1")))
+    (is (= [:num 1.5]   (formula/parse "1.5")))
+    (is (= [:num -2.0]  (formula/parse "-2"))))
+
+  (testing "metric refs"
+    (is (= [:ref "A"] (formula/parse "A"))))
+
+  (testing "operator precedence"
+    ;; A + B * C  =>  A + (B * C)
+    (is (= [:+ [:ref "A"] [:* [:ref "B"] [:ref "C"]]]
+           (formula/parse "A + B * C"))))
+
+  (testing "parentheses override"
+    (is (= [:* [:+ [:ref "A"] [:ref "B"]] [:ref "C"]]
+           (formula/parse "(A + B) * C"))))
+
+  (testing "left-associativity for same precedence"
+    ;; A - B - C  =>  (A - B) - C, not A - (B - C)
+    (is (= [:- [:- [:ref "A"] [:ref "B"]] [:ref "C"]]
+           (formula/parse "A - B - C"))))
+
+  (testing "real-world examples"
+    (is (some? (formula/parse "A / B * 100")))
+    (is (some? (formula/parse "(A - B) / A * 100"))))
+
+  (testing "unary minus on non-literals rewrites as 0 - expr"
+    (is (= [:- [:num 0.0] [:ref "A"]] (formula/parse "-A"))))
+
+  (testing "rejects invalid"
+    (is (thrown? Exception (formula/parse "")))
+    (is (thrown? Exception (formula/parse "A +")))
+    (is (thrown? Exception (formula/parse "A B")))
+    (is (thrown? Exception (formula/parse "A + (B")))
+    (is (thrown? Exception (formula/parse "@@")))
+    (is (thrown? Exception (formula/parse "AB")))))   ; refs are 1 char
+
+(deftest refs-test
+  (testing "extracts unique refs in order of first appearance"
+    (is (= ["A" "B"]     (formula/refs (formula/parse "A / B * 100"))))
+    (is (= ["A"]         (formula/refs (formula/parse "A * 2"))))
+    (is (= ["A" "B"]     (formula/refs (formula/parse "A + B + A"))))
+    (is (= []            (formula/refs (formula/parse "1 + 2"))))))
+
+(deftest eval-ast-test
+  (testing "literal"
+    (is (= 3.0 (formula/eval-ast [:num 3.0] {}))))
+  (testing "ref lookup"
+    (is (= 5.0 (formula/eval-ast [:ref "A"] {"A" 5.0}))))
+  (testing "arithmetic"
+    (is (= 7.0  (formula/eval-ast (formula/parse "A + 2") {"A" 5.0})))
+    (is (= 50.0 (formula/eval-ast (formula/parse "A / B * 100")
+                                  {"A" 1.0 "B" 2.0}))))
+  (testing "division by zero returns nil"
+    (is (nil? (formula/eval-ast (formula/parse "A / B")
+                                {"A" 1.0 "B" 0.0}))))
+  (testing "missing ref returns nil"
+    (is (nil? (formula/eval-ast (formula/parse "A + B") {"A" 1.0}))))
+  (testing "nil propagates"
+    (is (nil? (formula/eval-ast (formula/parse "A + B")
+                                {"A" 1.0 "B" nil})))))
+
+(defn- -ts
+  "Helper to build a series with bucket=>value pairs."
+  [id labels pairs]
+  {:id id
+   :labels labels
+   :data (mapv (fn [[t v]] {:timestamp t :value v}) pairs)})
+
+(deftest apply-formulas-test
+  (testing "single formula, no group_by labels"
+    (let [series [(-ts "A" {} [[1000 10.0] [2000 20.0]])
+                  (-ts "B" {} [[1000 2.0]  [2000 5.0]])]
+          formula {:id "F1" :expr "A / B"}
+          result (formula/apply-formulas series [formula])]
+      ;; Source series preserved
+      (is (= 3 (count result)))
+      (is (= [10.0 20.0] (mapv :value (:data (first result)))))
+      ;; Formula appended last
+      (let [f1 (last result)]
+        (is (= "F1" (:id f1)))
+        (is (= "A / B" (:formula f1)))
+        (is (= [{:timestamp 1000 :value 5.0}
+                {:timestamp 2000 :value 4.0}]
+               (:data f1))))))
+
+  (testing "inner-join on labels"
+    (let [series [(-ts "A" {:host "h1"} [[1000 10.0]])
+                  (-ts "A" {:host "h2"} [[1000 30.0]])
+                  (-ts "B" {:host "h1"} [[1000 2.0]])
+                  (-ts "B" {:host "h2"} [[1000 3.0]])]
+          formulas [{:id "F1" :expr "A / B"}]
+          result-formulas (filter #(= "F1" (:id %))
+                                  (formula/apply-formulas series formulas))]
+      (is (= 2 (count result-formulas)))
+      (is (= #{{:host "h1"} {:host "h2"}}
+             (set (map :labels result-formulas))))
+      (is (= {{:host "h1"} 5.0 {:host "h2"} 10.0}
+             (into {} (map (juxt :labels #(-> % :data first :value))
+                           result-formulas))))))
+
+  (testing "inner-join on bucket — missing bucket dropped"
+    (let [series [(-ts "A" {} [[1000 10.0] [2000 20.0]])
+                  (-ts "B" {} [[1000 2.0]])]                  ; no 2000
+          result (formula/apply-formulas series
+                                         [{:id "F1" :expr "A / B"}])
+          f1 (last result)]
+      (is (= [{:timestamp 1000 :value 5.0}] (:data f1)))))
+
+  (testing "division by zero — bucket dropped"
+    (let [series [(-ts "A" {} [[1000 10.0] [2000 20.0]])
+                  (-ts "B" {} [[1000 0.0]  [2000 5.0]])]
+          result (formula/apply-formulas series
+                                         [{:id "F1" :expr "A / B"}])
+          f1 (last result)]
+      (is (= [{:timestamp 2000 :value 4.0}] (:data f1)))))
+
+  (testing "name and unit echoed"
+    (let [series [(-ts "A" {} [[1000 1.0]])
+                  (-ts "B" {} [[1000 2.0]])]
+          formulas [{:id "F1" :expr "A / B" :name "ratio" :unit "%"}]
+          f1 (last (formula/apply-formulas series formulas))]
+      (is (= "F1: ratio" (:name f1)))
+      (is (= "%" (:unit f1)))))
+
+  (testing "missing operand series — formula yields zero series"
+    ;; Only A present, formula references B
+    (let [series [(-ts "A" {} [[1000 1.0]])]
+          result (formula/apply-formulas series
+                                         [{:id "F1" :expr "A / B"}])]
+      ;; Source preserved, no formula series emitted
+      (is (= 1 (count result)))
+      (is (= "A" (:id (first result))))))
+
+  (testing "empty formulas list returns source series unchanged"
+    (let [series [(-ts "A" {} [[1000 1.0]])]]
+      (is (= series (formula/apply-formulas series [])))))
+
+  (testing "single-ref formula"
+    (let [series [(-ts "A" {} [[1000 7.0] [2000 14.0]])]
+          f1 (last (formula/apply-formulas series [{:id "F1" :expr "A * 2"}]))]
+      (is (= [{:timestamp 1000 :value 14.0}
+              {:timestamp 2000 :value 28.0}] (:data f1)))))
+
+  (testing "multiple formulas evaluated independently"
+    (let [series [(-ts "A" {} [[1000 10.0]]) (-ts "B" {} [[1000 2.0]])]
+          result (formula/apply-formulas series
+                                         [{:id "F1" :expr "A + B"} {:id "F2" :expr "A / B"}])
+          by-id (group-by :id result)]
+      (is (= 12.0 (-> (get by-id "F1") first :data first :value)))
+      (is (= 5.0  (-> (get by-id "F2") first :data first :value))))))

--- a/backend/test/o11ylite/store/metrics/query_schema_test.clj
+++ b/backend/test/o11ylite/store/metrics/query_schema_test.clj
@@ -322,3 +322,52 @@
   (testing "having ref must be valid format"
     (is (invalid? (assoc (query-base) :having {:ref "a" :op ">" :value 80})))
     (is (invalid? (assoc (query-base) :having {:ref "AB" :op ">" :value 80})))))
+
+;; ---------------------------------------------------------
+;; Formulas Validation
+
+(deftest formulas-validation-test
+  (testing "formulas optional"
+    (is (valid? (query-base))))
+
+  (testing "valid formula"
+    (is (valid? (assoc (query-base)
+                       :metrics [{:id "A" :name "mem.free" :agg "avg"}
+                                 {:id "B" :name "mem.total" :agg "avg"}]
+                       :formulas [{:id "F1"
+                                   :expr "A / B * 100"
+                                   :name "free mem %"
+                                   :unit "%"}]))))
+
+  (testing "formula id must be F1-F9"
+    (is (invalid? (assoc (query-base)
+                         :formulas [{:id "X" :expr "A"}])))
+    (is (invalid? (assoc (query-base)
+                         :formulas [{:id "F0" :expr "A"}]))))
+
+  (testing "formula ids must be unique"
+    (is (invalid? (assoc (query-base)
+                         :metrics [{:id "A" :name "x" :agg "avg"}
+                                   {:id "B" :name "y" :agg "avg"}]
+                         :formulas [{:id "F1" :expr "A"}
+                                    {:id "F1" :expr "B"}]))))
+
+  (testing "formula expr must parse"
+    (is (invalid? (assoc (query-base)
+                         :formulas [{:id "F1" :expr "A +"}]))))
+
+  (testing "formula refs must reference declared metrics"
+    (is (invalid? (assoc (query-base)
+                         :metrics [{:id "A" :name "x" :agg "avg"}]
+                         :formulas [{:id "F1" :expr "A / B"}]))))
+
+  (testing "empty expr rejected"
+    (is (invalid? (assoc (query-base)
+                         :formulas [{:id "F1" :expr ""}])))
+    ;; whitespace-only slips past schema :min 1 and is caught by formula/parse
+    (is (invalid? (assoc (query-base)
+                         :formulas [{:id "F1" :expr "   "}]))))
+
+  (testing "formula must reference at least one metric"
+    (is (invalid? (assoc (query-base)
+                         :formulas [{:id "F1" :expr "1 + 2"}])))))

--- a/skills/o11ylite/docs/metrics-query.md
+++ b/skills/o11ylite/docs/metrics-query.md
@@ -59,7 +59,8 @@ Use the `attributes` list to know which fields are valid for `filter` and `group
   "bucket_ms": 60000,
   "filter": { ... },
   "group_by": ["attr.host.name"],
-  "having": { ... }
+  "having": { ... },
+  "formulas": [ ... ]
 }
 ```
 
@@ -71,6 +72,7 @@ Use the `attributes` list to know which fields are valid for `filter` and `group
 | `filter`    | No       | Global filter applied to all metrics                   |
 | `group_by`  | No       | Array of attribute names to group by (shared across metrics) |
 | `having`    | No       | Post-aggregation numeric filter                        |
+| `formulas`  | No       | Derived series computed over query results (max 10)    |
 
 ### Metric definition
 
@@ -111,6 +113,33 @@ Filter on aggregation results.
 
 - `ref` — references a metric `id`
 - `op` — `>`, `<`, `>=`, `<=`, `=`, `!=`
+
+### Formulas
+
+Compute derived series from query metrics. Source metric series are
+returned alongside formula series — the frontend decides what to render.
+
+```json
+{"id": "F1", "expr": "A / B * 100", "name": "free mem %", "unit": "%"}
+```
+
+| Field   | Required | Description                                                    |
+|---------|----------|----------------------------------------------------------------|
+| `id`    | Yes      | `F1`–`F9` (distinct namespace from metric IDs A–Z)             |
+| `expr`  | Yes      | Expression using `+ - * /`, parens, decimals, metric refs      |
+| `name`  | No       | Display name; result `name` becomes `"<id>: <name>"`           |
+| `unit`  | No       | Unit string surfaced in `units[<id>: <name>]`                  |
+
+Semantics:
+
+- Inner-join on `(bucket, labels)`. Source series share `group_by` so
+  labels match by construction.
+- Buckets where any operand is missing — or where division by zero
+  occurs — are dropped (no `null` / `NaN` propagation).
+- Each formula must reference at least one metric; constant-only
+  expressions like `1 + 2` are rejected at validation time.
+- Synthetic formula series carry `:metric null`, `:formula <expr>`, and
+  the requested `:unit` (when supplied).
 
 ---
 
@@ -178,6 +207,26 @@ One series per `(labels, metric)` combination. `labels` is `{}` when no `group_b
   "group_by": ["attr.http.route"]
 }
 ```
+
+### Free memory % via formula
+
+```json
+{
+  "time_range": {"start": 1700000000000, "end": 1700003600000},
+  "group_by": ["attr.host.name"],
+  "metrics": [
+    {"id": "A", "name": "system.memory.usage", "agg": "last",
+     "filter": {"field": "attr.state", "op": "=", "value": "free"}},
+    {"id": "B", "name": "system.memory.limit", "agg": "last"}
+  ],
+  "formulas": [
+    {"id": "F1", "expr": "A / B * 100", "name": "free memory %", "unit": "%"}
+  ]
+}
+```
+
+The response contains three series per host: `A` (free bytes), `B`
+(total bytes), and `F1: free memory %` (the derived percent).
 
 ---
 


### PR DESCRIPTION
Adds derived-series support to the metrics query API. Clients can request formulas like `A / B * 100` alongside raw metrics; the backend parses, validates, and joins the source series by `(bucket, labels)` to emit synthetic series in the response.

This unlocks the things you mentioned: free disk %, free memory %, error rate, cache hit rate, and any other algebra over the metrics already in the store.

## What

- Tiny expression language: `+ - * /`, parens, decimals, single-letter metric refs (A–Z). Pratt parser, no eval-of-strings.
- Formula evaluator with inner-join semantics on labels and timestamps.
- Schema (`F1`–`F9` ids, max 10 formulas) with cross-field validators: unique ids, parseable expr, refs resolve to declared metrics, must reference at least one metric (no constant-only).
- Wired into `query/execute`: synthetic series appended after metric series; units surfaced in `units` map keyed by `"<id>: <name>"`.
- Skill docs updated with a worked example (free memory %).

## Design choices

- **Source series are NOT suppressed.** The frontend decides whether to render `A`, `B`, and `F1` together or hide source series. Debuggability matters — when `A/B*100` looks weird you need to see both inputs.
- **No null/NaN propagation.** Buckets where any operand is missing or where division-by-zero occurs are dropped from the formula series.
- **Distinct ID namespace** (`F1`–`F9` vs `A`–`Z`) so formula vs metric IDs are visually unambiguous in responses and UI.

## Example

```json
{
  "time_range": {"start": 1700000000000, "end": 1700003600000},
  "group_by": ["attr.host.name"],
  "metrics": [
    {"id": "A", "name": "system.memory.usage", "agg": "last",
     "filter": {"field": "attr.state", "op": "=", "value": "free"}},
    {"id": "B", "name": "system.memory.limit", "agg": "last"}
  ],
  "formulas": [
    {"id": "F1", "expr": "A / B * 100", "name": "free memory %", "unit": "%"}
  ]
}
```

Response contains three series per host: `A` (free bytes), `B` (total bytes), and `F1: free memory %` (the derived percent).

## Test coverage

- **Unit** (`formula_test.clj`): parser (precedence, associativity, unary minus, error cases), ref extraction, single-bucket eval, `apply-formulas` series joins (label inner-join, bucket inner-join, div-by-zero, missing operand, multiple formulas).
- **Schema** (`query_schema_test.clj`): validators for parse failure, undeclared refs, duplicate ids, constant-only exprs, whitespace-only exprs.
- **Integration** (`metric_query_test.clj`): end-to-end POST `/api/query/metrics` with formulas asserting source+formula series, computed value, name/unit echo, and graceful no-op when no label combos match.

`34 tests, 190 assertions, 0 failures, 0 errors` across the affected namespaces. Frontend builds + tests still green (no frontend changes required — `TimeSeriesSeries.id?` already accommodated formula refs).

## Scope (V1)

**In:** `+ - * /`, parens, decimals, single-letter refs, name/unit echo.

**Out (deferred to V2+):** histogram percentiles, multi-letter ids, functions (`abs`, `clamp`, `if`), comparison/boolean ops, formulas referencing other formulas, auto-derived units across `/`.
