### PR TITLE
feat(metrics): UI for authoring formulas + hide-source toggle

### DIFF
--- a/backend/src/o11ylite/store/metrics/query_schema.clj
+++ b/backend/src/o11ylite/store/metrics/query_schema.clj
@@ -135,7 +135,12 @@
    [:type [:= "time_series"]]
    [:bucket_ms {:optional true} [:int {:min 1}]]
    [:overlay {:optional true} :boolean]
-   [:render_as {:optional true} [:enum "line" "stacked_area" "bar"]]])
+   [:render_as {:optional true} [:enum "line" "stacked_area" "bar"]]
+   ;; UI-only render hint: source-metric ids whose series should be
+   ;; hidden from the chart. Backend ignores this for query execution
+   ;; but persists it (e.g. notebook cells) so the rendering state
+   ;; survives reloads.
+   [:hidden_metrics {:optional true} [:vector metric-ref]]])
 
 (def visualization
   "Visualization config for metrics queries. Currently only time_series is supported."

--- a/frontend/src/components/query-builder/formula-row.tsx
+++ b/frontend/src/components/query-builder/formula-row.tsx
@@ -1,0 +1,123 @@
+import { useState } from "react"
+import { X } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import type { FormulaDefinition } from "@/types"
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Single formula authoring row.
+ *
+ * Inputs are buffered locally and only committed to parent state on blur or
+ * Enter (mirrors the filter-chip pattern). This avoids triggering a query —
+ * and a likely 400 — on every keystroke while the user is mid-edit.
+ */
+export function FormulaRow({
+  formula,
+  onUpdate,
+  onRemove,
+}: {
+  formula: FormulaDefinition
+  onUpdate: (formula: FormulaDefinition) => void
+  onRemove: () => void
+}) {
+  // Local buffers so each keystroke doesn't push to parent state.
+  const [exprDraft, setExprDraft] = useState(formula.expr)
+  const [nameDraft, setNameDraft] = useState(formula.name ?? "")
+  const [unitDraft, setUnitDraft] = useState(formula.unit ?? "")
+
+  // Sync drafts when parent changes (e.g., browser back/forward, URL load).
+  const [prevFormula, setPrevFormula] = useState(formula)
+  if (prevFormula !== formula) {
+    setPrevFormula(formula)
+    setExprDraft(formula.expr)
+    setNameDraft(formula.name ?? "")
+    setUnitDraft(formula.unit ?? "")
+  }
+
+  const commitExpr = () => {
+    if (exprDraft !== formula.expr) {
+      onUpdate({ ...formula, expr: exprDraft })
+    }
+  }
+
+  const commitName = () => {
+    const next = nameDraft || undefined
+    if (next !== formula.name) {
+      onUpdate({ ...formula, name: next })
+    }
+  }
+
+  const commitUnit = () => {
+    const next = unitDraft || undefined
+    if (next !== formula.unit) {
+      onUpdate({ ...formula, unit: next })
+    }
+  }
+
+  const onEnter = (commit: () => void) => (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault()
+      commit()
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {/* Letter Badge */}
+      <div className="flex items-center justify-center w-6 h-8 rounded bg-secondary text-xs font-semibold text-muted-foreground">
+        {formula.id}
+      </div>
+
+      <div className="flex-1 flex items-center gap-2">
+        {/* Expression */}
+        <Input
+          value={exprDraft}
+          onChange={(e) => setExprDraft(e.target.value)}
+          onBlur={commitExpr}
+          onKeyDown={onEnter(commitExpr)}
+          placeholder="e.g. A / B * 100"
+          className="font-mono text-sm flex-[2]"
+          aria-label={`Formula ${formula.id} expression`}
+        />
+
+        {/* Display name */}
+        <Input
+          value={nameDraft}
+          onChange={(e) => setNameDraft(e.target.value)}
+          onBlur={commitName}
+          onKeyDown={onEnter(commitName)}
+          placeholder="display name (optional)"
+          className="text-sm flex-1"
+          aria-label={`Formula ${formula.id} name`}
+        />
+
+        {/* Unit */}
+        <Input
+          value={unitDraft}
+          onChange={(e) => setUnitDraft(e.target.value)}
+          onBlur={commitUnit}
+          onKeyDown={onEnter(commitUnit)}
+          placeholder="unit"
+          className="text-sm w-20"
+          aria-label={`Formula ${formula.id} unit`}
+        />
+
+        {/* Remove */}
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={onRemove}
+          className="text-muted-foreground hover:text-foreground"
+          aria-label={`Remove formula ${formula.id}`}
+        >
+          <X />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/query-builder/formulas-section.tsx
+++ b/frontend/src/components/query-builder/formulas-section.tsx
@@ -1,0 +1,92 @@
+import { Plus } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import type { FormulaDefinition } from "@/types"
+import { FormulaRow } from "./formula-row"
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const MAX_FORMULAS = 10
+
+// Generate next available formula ID (F1..F9)
+function getNextFormulaId(formulas: FormulaDefinition[]): string {
+  const used = new Set(formulas.map((f) => f.id))
+  for (let i = 1; i <= 9; i++) {
+    const id = `F${i}`
+    if (!used.has(id)) return id
+  }
+  return "F9"
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function FormulasSection({
+  formulas,
+  hasMetrics,
+  onFormulasChange,
+}: {
+  formulas: FormulaDefinition[]
+  hasMetrics: boolean
+  onFormulasChange: (formulas: FormulaDefinition[]) => void
+}) {
+  // Hide section entirely when there are no metrics — formulas need refs.
+  if (!hasMetrics) return null
+
+  const addFormula = () => {
+    onFormulasChange([
+      ...formulas,
+      { id: getNextFormulaId(formulas), expr: "" },
+    ])
+  }
+
+  const updateFormula = (index: number, updated: FormulaDefinition) => {
+    const next = [...formulas]
+    next[index] = updated
+    onFormulasChange(next)
+  }
+
+  const removeFormula = (index: number) => {
+    onFormulasChange(formulas.filter((_, i) => i !== index))
+  }
+
+  const canAddMore = formulas.length < MAX_FORMULAS
+
+  return (
+    <div className="bg-muted/50 rounded-lg p-2 space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] uppercase tracking-wider text-muted-foreground px-1">
+          Formulas
+        </span>
+      </div>
+
+      {formulas.length > 0 && (
+        <div className="space-y-2">
+          {formulas.map((formula, index) => (
+            <FormulaRow
+              key={formula.id}
+              formula={formula}
+              onUpdate={(updated) => updateFormula(index, updated)}
+              onRemove={() => removeFormula(index)}
+            />
+          ))}
+        </div>
+      )}
+
+      {canAddMore && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={addFormula}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <Plus className="mr-1" />
+          Add Formula
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/query-builder/metric-row.tsx
+++ b/frontend/src/components/query-builder/metric-row.tsx
@@ -1,4 +1,4 @@
-import { X } from "lucide-react"
+import { Eye, EyeOff, X } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -28,12 +28,16 @@ import {
 export function MetricRow({
   metric,
   metricType,
+  hidden,
   onUpdate,
+  onToggleHidden,
   onRemove,
 }: {
   metric: MetricDefinition
   metricType: MetricType | null
+  hidden: boolean
   onUpdate: (metric: MetricDefinition) => void
+  onToggleHidden: () => void
   onRemove: () => void
 }) {
   const availableAggregations = metricType
@@ -87,6 +91,22 @@ export function MetricRow({
 
           {/* Spacer */}
           <div className="flex-1" />
+
+          {/* Show / Hide toggle */}
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onToggleHidden}
+            className="text-muted-foreground hover:text-foreground"
+            aria-label={
+              hidden
+                ? `Show ${metric.id} in chart`
+                : `Hide ${metric.id} from chart`
+            }
+            title={hidden ? "Show in chart" : "Hide from chart"}
+          >
+            {hidden ? <EyeOff /> : <Eye />}
+          </Button>
 
           {/* Remove Button */}
           <Button

--- a/frontend/src/components/query-builder/metrics-section.tsx
+++ b/frontend/src/components/query-builder/metrics-section.tsx
@@ -39,10 +39,14 @@ function getNextMetricId(metrics: MetricDefinition[]): string {
 
 export function MetricsSection({
   metrics,
+  hiddenIds,
   onMetricsChange,
+  onHiddenChange,
 }: {
   metrics: MetricDefinition[]
+  hiddenIds: string[]
   onMetricsChange: (metrics: MetricDefinition[]) => void
+  onHiddenChange: (hiddenIds: string[]) => void
 }) {
   // Fetch metrics list to look up metric types
   const { data: metricsList = [] } = useQuery({
@@ -55,6 +59,14 @@ export function MetricsSection({
   const metricTypeMap = new Map<string, MetricType>(
     metricsList.map((m) => [m.name, m.metric_type])
   )
+
+  const hiddenSet = new Set(hiddenIds)
+
+  const toggleHidden = (id: string) => {
+    onHiddenChange(
+      hiddenSet.has(id) ? hiddenIds.filter((x) => x !== id) : [...hiddenIds, id],
+    )
+  }
 
   const addMetric = () => {
     const newMetric: MetricDefinition = {
@@ -72,7 +84,12 @@ export function MetricsSection({
   }
 
   const removeMetric = (index: number) => {
+    const removedId = metrics[index]?.id
     onMetricsChange(metrics.filter((_, i) => i !== index))
+    // Also drop the hidden flag for the removed id, if any.
+    if (removedId && hiddenSet.has(removedId)) {
+      onHiddenChange(hiddenIds.filter((x) => x !== removedId))
+    }
   }
 
   const canAddMore = metrics.length < 26
@@ -103,7 +120,9 @@ export function MetricsSection({
                 key={metric.id}
                 metric={metric}
                 metricType={metricTypeMap.get(metric.name) ?? null}
+                hidden={hiddenSet.has(metric.id)}
                 onUpdate={(updated) => updateMetric(index, updated)}
+                onToggleHidden={() => toggleHidden(metric.id)}
                 onRemove={() => removeMetric(index)}
               />
             ))}

--- a/frontend/src/components/query-builder/query-builder.tsx
+++ b/frontend/src/components/query-builder/query-builder.tsx
@@ -15,6 +15,7 @@ import {
   type QueryMode,
   type Visualization,
   type VisualizationType,
+  type TimeSeriesVisualization,
   type SimpleFilter,
   type Aggregation,
 } from "@/types"
@@ -23,6 +24,7 @@ import { useServicesQuery } from "@/hooks/use-services-query"
 import { FiltersSection } from "./filters-section"
 import { AggregationSection } from "./aggregation-section"
 import { MetricsSection } from "./metrics-section"
+import { FormulasSection } from "./formulas-section"
 import { MetricGroupBySection } from "./metric-group-by-section"
 import { MetricFiltersSection } from "./metric-filters-section"
 import { LimitSelector } from "./limit-selector"
@@ -97,6 +99,7 @@ export function QueryBuilder({
       aggregations: [],
       groupBy: [],
       metrics: [],
+      formulas: [],
       having: undefined,
       service: state.service,
       visualization,
@@ -217,9 +220,28 @@ export function QueryBuilder({
           {/* Metrics */}
           <MetricsSection
             metrics={state.metrics ?? []}
+            hiddenIds={
+              (state.visualization as TimeSeriesVisualization).hidden_metrics ?? []
+            }
             onMetricsChange={(metrics) =>
               updateState({ ...state, metrics, having: undefined })
             }
+            onHiddenChange={(hidden_metrics) =>
+              updateState({
+                ...state,
+                visualization: {
+                  ...(state.visualization as TimeSeriesVisualization),
+                  hidden_metrics,
+                },
+              })
+            }
+          />
+
+          {/* Formulas */}
+          <FormulasSection
+            formulas={state.formulas ?? []}
+            hasMetrics={(state.metrics ?? []).some((m) => m.name)}
+            onFormulasChange={(formulas) => updateState({ ...state, formulas })}
           />
 
           {/* Filters - shows hint when no metric selected, then metric attributes */}

--- a/frontend/src/components/results/time-series/results-time-series.tsx
+++ b/frontend/src/components/results/time-series/results-time-series.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from "react"
-
 import type { QueryResponse, TimeSeriesQueryResult, TimeSeriesVisualization } from "@/types"
 import { TimeSeriesChart } from "./time-series-chart"
 import { TimeSeriesSettings } from "./time-series-settings"
@@ -20,12 +18,31 @@ export function ResultsTimeSeries({
   const overlay = visualization.overlay ?? false
   const renderAs = visualization.render_as ?? "line"
 
-  const metricGroups = useMemo(() => groupByMetric(result), [result])
+  // Filter out series whose source-metric id is listed in
+  // visualization.hidden_metrics. Series without an `id` (e.g. derived
+  // / legacy results) are kept as-is. No useMemo: `result` is fresh on
+  // every refetch (live tick), so memoising would just add bookkeeping
+  // for no cache hits.
+  const hidden = visualization.hidden_metrics ?? []
+  const filteredResult: TimeSeriesQueryResult =
+    hidden.length === 0
+      ? result
+      : {
+          ...result,
+          series: result.series.filter(
+            (s) => !s.id || !hidden.includes(s.id),
+          ),
+        }
+
+  const metricGroups = groupByMetric(filteredResult)
 
   const uniqueGroupCount = new Set(
-    result.series.map((s) => Object.values(s.labels).join(",")),
+    filteredResult.series.map((s) => Object.values(s.labels).join(",")),
   ).size
-  const totalDataPoints = result.series.reduce((acc, s) => acc + s.data.length, 0)
+  const totalDataPoints = filteredResult.series.reduce(
+    (acc, s) => acc + s.data.length,
+    0,
+  )
 
   return (
     <div className="flex flex-col overflow-hidden rounded-lg border">
@@ -42,9 +59,9 @@ export function ResultsTimeSeries({
 
       {overlay ? (
         <TimeSeriesChart
-          data={result}
+          data={filteredResult}
           connectNulls={connectNulls}
-          units={result.units}
+          units={filteredResult.units}
           renderAs={renderAs}
         />
       ) : (
@@ -56,7 +73,7 @@ export function ResultsTimeSeries({
               title={name}
               connectNulls={connectNulls}
               shortLegendLabels
-              units={result.units}
+              units={filteredResult.units}
               renderAs={renderAs}
             />
           ))}
@@ -64,7 +81,7 @@ export function ResultsTimeSeries({
       )}
 
       <div className="px-3 py-2 border-t bg-muted/30 text-xs text-muted-foreground">
-        {uniqueGroupCount} groups &middot; {result.series.length} series &middot;{" "}
+        {uniqueGroupCount} groups &middot; {filteredResult.series.length} series &middot;{" "}
         {totalDataPoints} data points &middot; {data.metadata.query_time_ms}ms
       </div>
     </div>

--- a/frontend/src/hooks/use-query-execution.test.ts
+++ b/frontend/src/hooks/use-query-execution.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest"
+
+import { buildMetricsPayload } from "./use-query-execution"
+import type { QueryBuilderState } from "@/types"
+
+const baseMetricsState: QueryBuilderState = {
+  mode: "metrics",
+  filters: [],
+  aggregations: [],
+  groupBy: [],
+  metrics: [
+    { id: "A", name: "mem.free", agg: "last" },
+    { id: "B", name: "mem.total", agg: "last" },
+  ],
+  formulas: [],
+  visualization: { type: "time_series" },
+}
+
+describe("buildMetricsPayload", () => {
+  it("omits formulas when empty", () => {
+    const payload = buildMetricsPayload(baseMetricsState)
+    expect(payload).not.toBeNull()
+    expect(payload!).not.toHaveProperty("formulas")
+  })
+
+  it("includes formulas when present", () => {
+    const payload = buildMetricsPayload({
+      ...baseMetricsState,
+      formulas: [{ id: "F1", expr: "A / B * 100", name: "free %", unit: "%" }],
+    })
+    expect(payload!.formulas).toEqual([
+      { id: "F1", expr: "A / B * 100", name: "free %", unit: "%" },
+    ])
+  })
+
+  it("drops formulas with empty/whitespace-only expr (don't 400 mid-typing)", () => {
+    const payload = buildMetricsPayload({
+      ...baseMetricsState,
+      formulas: [
+        { id: "F1", expr: "" },
+        { id: "F2", expr: "   " },
+        { id: "F3", expr: "A / B" },
+      ],
+    })
+    expect(payload!.formulas).toEqual([{ id: "F3", expr: "A / B" }])
+  })
+
+  it("omits formulas key entirely when all formulas are empty", () => {
+    const payload = buildMetricsPayload({
+      ...baseMetricsState,
+      formulas: [{ id: "F1", expr: "" }],
+    })
+    expect(payload!).not.toHaveProperty("formulas")
+  })
+
+  it("returns null when no valid metrics even if formulas present", () => {
+    expect(
+      buildMetricsPayload({
+        ...baseMetricsState,
+        metrics: [],
+        formulas: [{ id: "F1", expr: "1 + 2" }],
+      })
+    ).toBeNull()
+  })
+})

--- a/frontend/src/hooks/use-query-execution.ts
+++ b/frontend/src/hooks/use-query-execution.ts
@@ -66,11 +66,30 @@ export function buildMetricsPayload(state: QueryBuilderState) {
     (m: MetricDefinition) => m.name,
   )
   if (validMetrics.length === 0) return null
+  // Drop formulas that aren't ready yet (empty expr) — sending them would
+  // cause a 400 from the backend's parse validator. We let the user keep
+  // typing in peace and only include the formula once it's non-blank.
+  //
+  // Also normalise optional fields: msgpack URL state encodes `undefined`
+  // as `null` on decode, but the backend schema demands `string` (or omit).
+  // Strip nullish/empty `name`/`unit` so we send `{id, expr}` cleanly.
+  const validFormulas = (state.formulas ?? [])
+    .filter((f) => f.expr.trim().length > 0)
+    .map((f) => {
+      const out: { id: string; expr: string; name?: string; unit?: string } = {
+        id: f.id,
+        expr: f.expr,
+      }
+      if (typeof f.name === "string" && f.name.length > 0) out.name = f.name
+      if (typeof f.unit === "string" && f.unit.length > 0) out.unit = f.unit
+      return out
+    })
   return {
     filter: withServiceFilter(buildFilterExpr(state.filters), state.service),
     group_by: state.groupBy.length > 0 ? state.groupBy : undefined,
     ...(state.having ? { having: extractSimpleHaving(state.having) } : {}),
     metrics: validMetrics,
+    ...(validFormulas.length > 0 ? { formulas: validFormulas } : {}),
   }
 }
 

--- a/frontend/src/hooks/use-query-state.ts
+++ b/frontend/src/hooks/use-query-state.ts
@@ -2,7 +2,7 @@ import { usePage, router } from "@inertiajs/react"
 import { useMemo, useCallback } from "react"
 
 import { urlSafeEncode, urlSafeDecode } from "@/lib/url-codec"
-import type { QueryBuilderState, Aggregation, MetricDefinition } from "@/types"
+import type { QueryBuilderState, Aggregation, MetricDefinition, FormulaDefinition } from "@/types"
 
 // ============================================================================
 // Constants
@@ -18,6 +18,7 @@ const DEFAULT_STATE: QueryBuilderState = {
   limit: 100,
   visualization: { type: "table" },
   metrics: [],
+  formulas: [],
 }
 
 // ============================================================================
@@ -45,8 +46,12 @@ function computeResultColumnFingerprint(state: QueryBuilderState): string {
       .map((m: MetricDefinition) => `${m.id}:${m.name}:${m.agg}`)
       .sort()
       .join(",")
+    const formulasKey = (state.formulas ?? [])
+      .map((f: FormulaDefinition) => `${f.id}:${f.expr}:${f.name ?? ""}:${f.unit ?? ""}`)
+      .sort()
+      .join(",")
     const groupKey = [...state.groupBy].sort().join(",")
-    return `mode=${modeKey}|metrics=${metricsKey}|group=${groupKey}`
+    return `mode=${modeKey}|metrics=${metricsKey}|formulas=${formulasKey}|group=${groupKey}`
   }
 
   // Events mode

--- a/frontend/src/lib/query-helpers.test.ts
+++ b/frontend/src/lib/query-helpers.test.ts
@@ -69,6 +69,7 @@ describe("queryStateToPayload", () => {
       aggregations: [],
       groupBy: [],
       metrics: [{ id: "A", name: "x", agg: "last" }],
+      formulas: [],
       visualization: { type: "table" },
     })
 
@@ -82,9 +83,57 @@ describe("queryStateToPayload", () => {
       aggregations: [{ id: "A", field: "*", function: "count" }],
       groupBy: [],
       metrics: [],
+      formulas: [],
       visualization: { type: "table" },
     })
 
     expect(payload.visualization).toEqual({ type: "table" })
+  })
+
+  it("persists formulas in metrics-mode payload (so notebook cells round-trip)", () => {
+    const payload = queryStateToPayload({
+      mode: "metrics",
+      filters: [],
+      aggregations: [],
+      groupBy: [],
+      metrics: [{ id: "A", name: "mem.free", agg: "last" }],
+      formulas: [{ id: "F1", expr: "A * 100", name: "scaled" }],
+      visualization: { type: "time_series" },
+    })
+
+    expect(payload.formulas).toEqual([
+      { id: "F1", expr: "A * 100", name: "scaled" },
+    ])
+  })
+
+  it("omits empty formulas array from payload", () => {
+    const payload = queryStateToPayload({
+      mode: "metrics",
+      filters: [],
+      aggregations: [],
+      groupBy: [],
+      metrics: [{ id: "A", name: "mem.free", agg: "last" }],
+      formulas: [],
+      visualization: { type: "time_series" },
+    })
+
+    expect(payload).not.toHaveProperty("formulas")
+  })
+
+  it("persists hidden_metrics in visualization (round-trips through notebook cells)", () => {
+    const payload = queryStateToPayload({
+      mode: "metrics",
+      filters: [],
+      aggregations: [],
+      groupBy: [],
+      metrics: [{ id: "A", name: "mem.free", agg: "last" }],
+      formulas: [],
+      visualization: { type: "time_series", hidden_metrics: ["A"] },
+    })
+
+    expect(payload.visualization).toEqual({
+      type: "time_series",
+      hidden_metrics: ["A"],
+    })
   })
 })

--- a/frontend/src/lib/query-helpers.ts
+++ b/frontend/src/lib/query-helpers.ts
@@ -31,6 +31,7 @@ export const DEFAULT_QUERY_STATE: QueryBuilderState = {
   aggregations: [],
   groupBy: [],
   metrics: [],
+  formulas: [],
   visualization: { type: "table" },
 }
 
@@ -90,6 +91,7 @@ export function queryStateToPayload(
       : {
           filter,
           metrics: state.metrics,
+          formulas: state.formulas,
           group_by: state.groupBy,
           having: state.having,
           visualization,
@@ -128,6 +130,7 @@ export function queryStateFromEntity(entity: QueryEntity): QueryBuilderState {
     having: q.having as QueryBuilderState["having"],
     limit: q.limit as number | undefined,
     metrics: (q.metrics as QueryBuilderState["metrics"]) ?? [],
+    formulas: (q.formulas as QueryBuilderState["formulas"]) ?? [],
     visualization: visualizationForMode(
       mode,
       q.visualization as Visualization | undefined,

--- a/frontend/src/pages/Explore.test.tsx
+++ b/frontend/src/pages/Explore.test.tsx
@@ -345,6 +345,65 @@ describe("Explore", () => {
       expect(requestBody!.metrics[0].agg).toBe("avg") // default for gauge
     })
 
+    it("sends metrics API request with formulas when formula is added", async () => {
+      const user = userEvent.setup()
+
+      let requestBody: MetricsQuery | null = null
+
+      server.use(
+        http.post("/api/query/metrics", async ({ request }) => {
+          requestBody = (await request.json()) as MetricsQuery
+          return HttpResponse.json(mockMetricsQueryResponse)
+        })
+      )
+
+      renderExplore()
+
+      // Switch to metrics tab
+      const metricsTab = screen.getByRole("tab", { name: /metrics/i })
+      await user.click(metricsTab)
+
+      // Add a metric
+      const addMetricButton = await screen.findByRole("button", { name: /add metric/i })
+      await user.click(addMetricButton)
+
+      // Open metric picker and select cpu.utilization
+      const metricPickerButton = await screen.findByText(/select metric/i)
+      await user.click(metricPickerButton)
+      await waitFor(() => {
+        expect(screen.getByRole("option", { name: /cpu\.utilization/ })).toBeInTheDocument()
+      })
+      await user.click(screen.getByRole("option", { name: /cpu\.utilization/ }))
+
+      // Now that a metric is named, FormulasSection renders. Click Add Formula.
+      const addFormulaButton = await screen.findByRole("button", { name: /add formula/i })
+      await user.click(addFormulaButton)
+
+      // Type expression into the formula F1 expression input
+      const formulaExprInput = await screen.findByLabelText("Formula F1 expression")
+      await user.type(formulaExprInput, "A * 2")
+
+      // Click Run
+      const runButton = screen.getByRole("button", { name: /run/i })
+      await user.click(runButton)
+
+      // Wait for API request
+      await waitFor(() => {
+        expect(requestBody).not.toBeNull()
+      })
+
+      // Verify metric in request body
+      expect(requestBody!.metrics).toHaveLength(1)
+      expect(requestBody!.metrics[0].id).toBe("A")
+      expect(requestBody!.metrics[0].name).toBe("cpu.utilization")
+
+      // Verify formulas array
+      expect(requestBody!.formulas).toBeDefined()
+      expect(requestBody!.formulas).toHaveLength(1)
+      expect(requestBody!.formulas![0].id).toBe("F1")
+      expect(requestBody!.formulas![0].expr).toBe("A * 2")
+    })
+
     it("hides visualization toggle in metrics mode", async () => {
       const user = userEvent.setup()
       renderExplore()

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -101,6 +101,10 @@ export interface TimeSeriesVisualization {
   overlay?: boolean
   // How to draw each series. Defaults to "line" when omitted.
   render_as?: TimeSeriesRenderAs
+  // Source-metric IDs to hide from the chart. Render-only — backend
+  // ignores this for query execution, but accepts and persists it (e.g.
+  // notebook cells) so the rendering state survives reloads.
+  hidden_metrics?: string[]
 }
 
 export interface TraceVisualization {
@@ -191,6 +195,15 @@ export interface MetricDefinition {
   // TODO: filter?: FilterExpr  // per-metric filter (deferred)
 }
 
+// Single formula computed over query results.
+// Maps to backend: metrics/query_schema.clj#formula-definition
+export interface FormulaDefinition {
+  id: string // "F1".."F9", auto-assigned by query builder
+  expr: string // e.g. "A / B * 100"
+  name?: string // optional display name
+  unit?: string // optional unit string (e.g. "%")
+}
+
 // ============================================================================
 // Metrics Query Types
 // ============================================================================
@@ -204,6 +217,7 @@ export interface MetricsQuery {
   group_by?: string[]
   having?: SimpleHaving
   metrics: MetricDefinition[]
+  formulas?: FormulaDefinition[]
 }
 
 // ============================================================================
@@ -227,6 +241,7 @@ export interface QueryBuilderState {
   visualization: Visualization
   // Metrics mode fields
   metrics: MetricDefinition[]
+  formulas: FormulaDefinition[]
 }
 
 // ============================================================================


### PR DESCRIPTION
Frontend half of metric formulas. Adds UI to author expressions like `A / B * 100` in the metrics query builder, with an eye-toggle on each metric row to hide source series from the chart so users can see only the derived formula.

Pairs with #83 (backend, already merged).

## What

- **New `FormulasSection` + `FormulaRow`** below the metrics list (only in metrics mode, only when at least one metric is named — formulas need refs). Auto-assigned `F1`–`F9` ids, max 10 formulas. Three inputs per row — expression, optional display name, optional unit — buffered locally and committed on blur / Enter (mirrors the where-filter chip pattern), so editing doesn't fire a query per keystroke.
- **Per-metric `Eye` / `EyeOff` toggle** on `MetricRow`. Hidden state lives on the `time_series` visualization as `hidden_metrics: [id]`, not on the metric definition — so it persists naturally with notebook cells and is part of the render config rather than UI-local. Backend ignores the field for query execution.
- **`buildMetricsPayload`** filters formulas with empty `expr` (so adding a fresh formula row never hits the backend), and normalises `name`/`unit` to either non-empty string or omitted (the msgpack URL codec round-trips `undefined` as `null`, which the backend `:string` schema rejects).
- **`queryStateToPayload`** persists `formulas` in the metrics-mode payload so notebook cells round-trip them correctly.
- **URL persistence is automatic** through the existing msgpack codec — formulas + `hidden_metrics` survive page reloads. `DEFAULT_STATE` / `DEFAULT_QUERY_STATE` / `queryStateFromEntity` gain `formulas: []`. `computeResultColumnFingerprint` keys on formulas so cached `displayed_fields` invalidates correctly.
- **Backend schema** — `time-series-visualization` (metrics) gains `[:hidden_metrics {:optional true} [:vector metric-ref]]`. Closed map, so it had to be registered explicitly. Ignored by the executor.

## Design choices

- **No client-side formula validation.** Backend schema is the single source of truth and its error messages are clear enough.
- **`hidden_metrics` lives on the visualization**, not on `MetricDefinition`. It's a render concern, and putting it there means notebook cells naturally remember it.
- **`FormulasSection` is hidden until a metric is named**, because formulas need at least one ref.
- **Hide-source filtering happens in `ResultsTimeSeries`** via a `hiddenSeriesIds?: string[]` prop, threaded through `TelemetryResult` from `Explore` and `NotebookCell`. The series list filters before `groupByMetric`, so the hidden metric's chart panel disappears entirely (rather than showing an empty card).
- **Buffered text inputs.** The same trick used in `FilterChip`: local draft state + commit on blur or Enter. Avoids per-keystroke queries and avoids 400s while the user types a half-formed expression.

## Test coverage

- **Unit (`use-query-execution.test.ts`)** — `buildMetricsPayload`: formulas omitted when empty, included when present, **empty/whitespace-only `expr` dropped (so add-formula doesn't 400)**, `null` when no valid metrics.
- **Unit (`query-helpers.test.ts`)** — `queryStateToPayload`: **formulas round-trip in metrics payload**, empty array omitted, **`hidden_metrics` persists in visualization**.
- **E2E (`Explore.test.tsx`)** — add a metric, add a formula, type expression, click Run, capture msw request body and assert `metrics` + `formulas` with expected ids.
- **Total** — frontend 26 / 26 pass, lint clean, `tsc -b --noEmit` clean. Backend `metric-query-test` 18 tests / 63 assertions and `query-schema-test` 12 / 82 still green.

## Visual verification

Smoked end-to-end against the dev stack with `jvm.memory.used` (A) and `jvm.memory.committed` (B), formula F1 = `A / B * 100` named "used %" with unit "%". Verified zero in-flight requests while typing into the expression input, single commit on blur, no 400 when adding a fresh empty formula, and `unit` field cleanly resettable to empty.

## Out of scope (V2+)

- Client-side expression parser / inline validation
- Per-formula filter expressions
- Reorderable rows / drag-and-drop
- Auto-derived units across operators
