### PR TITLE
improve alert webhook payload with breach context

### DIFF
--- a/backend/src/o11ylite/alert_rule/eval.clj
+++ b/backend/src/o11ylite/alert_rule/eval.clj
@@ -104,8 +104,10 @@
    The alert_on field controls interpretation: 'result' (default) fires on
    non-empty results, 'no_result' fires on empty results (absence detection).
 
-   Returns {:state :ok|:firing, :error nil} on success,
-   or {:state nil, :error string} on failure (caller preserves prev state)."
+   Returns {:state :ok|:firing, :error nil, :result <query-result>} on
+   success, or {:state nil, :error string, :result nil} on failure (caller
+   preserves prev state). The :result key carries the query response so
+   notification dispatch can include breach context in the payload."
   [duckdb sqlite events-schema {qmode :query_mode query :query
                                 eval-win :eval_window_ms
                                 alert-on :alert_on
@@ -117,15 +119,18 @@
       (case qmode
         "events"
         (if-let [validation-error (events.query/validate events-schema full-query)]
-          {:state nil :error (str "Validation error: " (:error validation-error))}
+          {:state nil :error (str "Validation error: " (:error validation-error))
+           :result nil}
           (let [result (events.query/execute duckdb full-query)]
             {:state (-resolve-state (-events-result-firing? result) alert-on)
-             :error nil}))
+             :error nil
+             :result result}))
 
         "metrics"
         (let [metrics-query (-inject-time-range query eval-win)]
           (if-let [validation-error (metrics.query/validate sqlite metrics-query)]
-            {:state nil :error (str "Validation error: " (:error validation-error))}
+            {:state nil :error (str "Validation error: " (:error validation-error))
+             :result nil}
             ;; :single-bucket? collapses every metric to one row per
             ;; group_by combination over the full eval window so HAVING
             ;; applies to the full window, not per sub-bucket.
@@ -133,13 +138,14 @@
                                                 {:single-bucket? true})
                   firing? (-metrics-result-firing? result alert-target)]
               {:state (-resolve-state firing? alert-on)
-               :error nil})))
+               :error nil
+               :result result})))
 
         ;; Unknown mode
-        {:state nil :error (str "Unknown query_mode: " qmode)}))
+        {:state nil :error (str "Unknown query_mode: " qmode) :result nil}))
     (catch Exception e
       (mulog/log ::evaluation-error :error (.getMessage e))
-      {:state nil :error (.getMessage e)})))
+      {:state nil :error (.getMessage e) :result nil})))
 
 ;; ---------------------------------------------------------
 ;; Evaluation Cycle Orchestration
@@ -150,17 +156,18 @@
   [duckdb sqlite events-schema webhook-url rule]
   (let [{:keys [id state]} rule
         prev-state (keyword state)
-        {:keys [state error]} (evaluate-rule duckdb sqlite events-schema rule)
-        new-state (or state prev-state)]
+        {new-state :state error :error result :result}
+        (evaluate-rule duckdb sqlite events-schema rule)
+        effective-state (or new-state prev-state)]
     (mulog/log ::rule-evaluated
                :rule-id id
                :prev-state prev-state
-               :new-state new-state
+               :new-state effective-state
                :error error)
     ;; Update DB state (records last_eval_at and error even on failure)
-    (store/update-eval-result! sqlite id new-state error prev-state)
-    ;; Send webhook notification
-    (notify/maybe-send-webhook! webhook-url rule new-state prev-state)))
+    (store/update-eval-result! sqlite id effective-state error prev-state)
+    ;; Send webhook notification with breach context from the query result
+    (notify/maybe-send-webhook! webhook-url rule effective-state prev-state result)))
 
 (defn run-evaluation-cycle!
   "Evaluate all due alert rules and send notifications.

--- a/backend/src/o11ylite/alert_rule/notify.clj
+++ b/backend/src/o11ylite/alert_rule/notify.clj
@@ -14,6 +14,7 @@
 (ns o11ylite.alert-rule.notify
   (:require
     [babashka.http-client :as http]
+    [clojure.string :as str]
     [com.brunobonacci.mulog :as mulog]
     [jsonista.core :as json])
   (:import
@@ -21,7 +22,7 @@
     [java.time.format DateTimeFormatter]))
 
 ;; ---------------------------------------------------------
-;; Private Helpers
+;; Private Helpers — formatting
 
 (defn- -epoch-ms->rfc3339
   "Convert epoch milliseconds to RFC3339 string."
@@ -35,16 +36,137 @@
   [rule-id]
   (format "%016x" (hash rule-id)))
 
+(defn- -format-number
+  "Trim trailing .0 from doubles that are integer-valued for nicer display."
+  [v]
+  (cond
+    (nil? v) "null"
+    (and (number? v) (== (double v) (long v))) (str (long v))
+    (number? v) (format "%.4g" (double v))
+    :else (str v)))
+
+(def ^:private ^:const max-breach-rows 5)
+
+;; ---------------------------------------------------------
+;; Private Helpers — events result summarization
+
+(defn- -row-label
+  "Render a single events row as a compact `k=v, k=v` label.
+   Drops keys that look like timestamps or have nil values, keeping
+   group-by + aggregation columns which are what the user cares about."
+  [row]
+  (->> row
+       (remove (fn [[k v]]
+                 (or (nil? v)
+                     (#{:timestamp :start_ms :end_ms :bucket_ms} k))))
+       (map (fn [[k v]] (str (name k) "=" (-format-number v))))
+       (str/join ", ")))
+
+(defn- -summarize-events-result
+  "Build {:summary, :details} strings from an events query result.
+   `result` shape: {:data {:rows [{...}] :total_count N :columns [...]}}.
+   Returns nil-valued keys when the result is empty (no_result firing)."
+  [result]
+  (let [rows (get-in result [:data :rows])
+        total (or (get-in result [:data :total_count]) (count rows))]
+    (if (seq rows)
+      (let [top (take max-breach-rows rows)
+            labels (mapv -row-label top)
+            more (- total (count top))
+            details-lines (cond-> labels
+                            (pos? more) (conj (str "... and " more " more")))]
+        {:summary (format "%d group(s) breached: %s"
+                          total
+                          (str/join " | " (take 3 labels)))
+         :details (str/join "\n" details-lines)})
+      {:summary nil :details nil})))
+
+;; ---------------------------------------------------------
+;; Private Helpers — metrics result summarization
+
+(defn- -last-data-point
+  "Return the most recent {:timestamp :value} of a series, or nil if empty."
+  [series]
+  (last (:data series)))
+
+(defn- -series-label
+  "Render a metrics series as `name{labels}=value` for breach summaries."
+  [series]
+  (let [labels (some->> (:labels series)
+                        seq
+                        (map (fn [[k v]] (str (name k) "=" v)))
+                        (str/join ","))
+        last-pt (-last-data-point series)
+        v (some-> last-pt :value -format-number)
+        base (or (:name series) (:id series))]
+    (str base
+         (when (seq labels) (str "{" labels "}"))
+         (when v (str "=" v)))))
+
+(defn- -summarize-metrics-result
+  "Build {:summary, :details} strings from a metrics query result.
+   `result` shape: {:data {:series [{:id :name :labels :data}] :bucket_ms ...}}.
+   When `alert-target` is set, restrict to that ref so the summary matches
+   what actually fired."
+  [result alert-target]
+  (let [all-series (get-in result [:data :series])
+        series (cond->> all-series
+                 alert-target (filterv #(= alert-target (:id %))))
+        breaching (filterv #(seq (:data %)) series)]
+    (if (seq breaching)
+      (let [top (take max-breach-rows breaching)
+            labels (mapv -series-label top)
+            more (- (count breaching) (count top))
+            details-lines (cond-> labels
+                            (pos? more) (conj (str "... and " more " more")))]
+        {:summary (format "%d series breached: %s"
+                          (count breaching)
+                          (str/join " | " (take 3 labels)))
+         :details (str/join "\n" details-lines)})
+      {:summary nil :details nil})))
+
+;; ---------------------------------------------------------
+;; Private Helpers — payload assembly
+
+(defn- -summary-for
+  "Pick the right summarizer based on rule shape, defensive against missing data.
+   Returns {:summary, :details}; values may be nil (e.g. resolved alert,
+   no_result firing with empty rows, or evaluation error path)."
+  [{:keys [query_mode alert_target alert_on]} status result]
+  (cond
+    (nil? result) {:summary nil :details nil}
+
+    (and (= status "firing") (= alert_on "no_result"))
+    {:summary "Query returned no results (no_result mode firing)."
+     :details nil}
+
+    (= query_mode "events") (-summarize-events-result result)
+    (= query_mode "metrics") (-summarize-metrics-result result alert_target)
+    :else {:summary nil :details nil}))
+
 (defn- -build-payload
-  "Build Alertmanager POST body."
-  [{:keys [id name description state_changed_at]} status]
+  "Build Alertmanager POST body. Result-derived breach context is included
+   when available (firing path with non-empty result data)."
+  [{:keys [id name description state_changed_at eval_window_ms] :as rule}
+   status
+   result]
   (let [now-ms (System/currentTimeMillis)
         starts-at (-epoch-ms->rfc3339 (or state_changed_at now-ms))
         ends-at (when (= status "resolved") now-ms)
+        {:keys [summary details]} (-summary-for rule status result)
+        ;; Labels are kept minimal: only the structural keys Alertmanager
+        ;; expects (alertname) plus a constant source. Rule-shape metadata
+        ;; (query_mode, alert_on, alert_target, eval_window) is *not* useful
+        ;; for routing/grouping and would just pollute the label namespace.
+        ;; User-defined labels are a planned follow-up.
         labels {"alertname" name
                 "source" "o11ylite"}
         annotations (cond-> {}
-                      description (assoc "description" description))]
+                      description (assoc "description" description)
+                      summary (assoc "summary" summary)
+                      details (assoc "breach_details" details)
+                      eval_window_ms (assoc "eval_window_ms"
+                                            (str eval_window_ms)))]
     [{:labels labels
       :annotations annotations
       :startsAt starts-at
@@ -70,8 +192,12 @@
 
 (defn maybe-send-webhook!
   "Send Alertmanager-compatible webhook if appropriate.
+   `result` is the query result that drove the evaluation, used to enrich
+   the payload with breach context. Pass nil when a result isn't available
+   (e.g. evaluation error path).
+
    Returns nil. Logs errors but does not throw."
-  [webhook-url rule new-state prev-state]
+  [webhook-url rule new-state prev-state result]
   (when webhook-url
     (let [should-send? (or (= new-state :firing)
                            (and (= prev-state :firing) (= new-state :ok)))
@@ -81,7 +207,7 @@
                    nil)]
       (when (and should-send? status)
         (try
-          (let [payload (-build-payload rule status)
+          (let [payload (-build-payload rule status result)
                 body (json/write-value-as-string payload)]
             (mulog/log ::sending-webhook
                        :rule-id (:id rule)
@@ -97,13 +223,28 @@
 ;; Rich Comment
 (comment
 
-  ;; Build a sample payload
+  ;; Build a sample events payload with breach context
   (-build-payload
     {:id "12345"
      :name "High error rate"
      :description "Error count exceeded threshold"
-     :state_changed_at 1702000000000}
-    "firing")
+     :state_changed_at 1702000000000
+     :query_mode "events"
+     :eval_window_ms 300000
+     :alert_on "result"}
+    "firing"
+    {:data {:rows [{:service "api" :count 147}
+                   {:service "worker" :count 132}]
+            :total_count 2}})
+
+  ;; Build a sample metrics payload
+  (-build-payload
+    {:id "abc" :name "CPU critical" :query_mode "metrics"
+     :eval_window_ms 60000 :alert_on "result"}
+    "firing"
+    {:data {:series [{:id "A" :name "cpu.utilization"
+                      :labels {"host" "node-1"}
+                      :data [{:timestamp 1 :value 95.5}]}]}})
 
   #_()) ; End of rich comment block
 ;; ---------------------------------------------------------

--- a/backend/test/o11ylite/alert_rule/notify_test.clj
+++ b/backend/test/o11ylite/alert_rule/notify_test.clj
@@ -1,0 +1,170 @@
+;; ---------------------------------------------------------
+;; o11ylite.alert-rule.notify-test
+;;
+;; Unit tests for the Alertmanager-compatible payload builder.
+;; Tests are pure function checks against the private builder via
+;; #' var access — no system fixture required.
+;; ---------------------------------------------------------
+
+(ns o11ylite.alert-rule.notify-test
+  (:require
+    [clojure.string :as str]
+    [clojure.test :refer [deftest is testing]]
+    [o11ylite.alert-rule.notify :as notify]))
+
+;; ---------------------------------------------------------
+;; Helpers
+
+(def ^:private build-payload @#'notify/-build-payload)
+
+(defn- single-alert
+  "Builders return a vector with one alert map; pull it out."
+  [payload]
+  (first payload))
+
+(def base-rule
+  {:id "rule-123"
+   :name "High error rate"
+   :description "Errors exceed threshold"
+   :state_changed_at 1702000000000
+   :query_mode "events"
+   :eval_window_ms 300000
+   :alert_on "result"})
+
+;; ---------------------------------------------------------
+;; Labels
+
+(deftest labels-are-minimal-test
+  (testing "labels carry only alertname + source — rule-shape metadata stays out"
+    (let [rule (assoc base-rule
+                      :query_mode "metrics"
+                      :alert_on "no_result"
+                      :alert_target "F1")
+          {:keys [labels]} (single-alert (build-payload rule "firing" nil))]
+      (is (= #{"alertname" "source"} (set (keys labels)))
+          "labels should be exactly alertname + source")
+      (is (= "High error rate" (get labels "alertname")))
+      (is (= "o11ylite" (get labels "source")))
+      (is (nil? (get labels "query_mode"))
+          "query_mode is not a routing key — keep it out of labels")
+      (is (nil? (get labels "alert_on"))
+          "alert_on is not a routing key — keep it out of labels")
+      (is (nil? (get labels "alert_target"))
+          "alert_target is not a routing key — keep it out of labels")
+      (is (nil? (get labels "eval_window"))
+          "eval_window is not a routing key — eval_window_ms in annotations is enough"))))
+
+;; ---------------------------------------------------------
+;; Annotations — events firing path
+
+(deftest events-firing-includes-breach-summary-test
+  (testing "events firing payload includes summary + details from rows"
+    (let [result {:data {:rows [{:service "api" :count 147}
+                                {:service "worker" :count 132}]
+                         :total_count 2}}
+          {:keys [annotations]} (single-alert (build-payload base-rule "firing" result))]
+      (is (= "Errors exceed threshold" (get annotations "description")))
+      (is (str/includes? (get annotations "summary") "2 group(s) breached"))
+      (is (str/includes? (get annotations "summary") "service=api"))
+      (is (str/includes? (get annotations "summary") "count=147"))
+      (let [details (get annotations "breach_details")]
+        (is (str/includes? details "service=api, count=147"))
+        (is (str/includes? details "service=worker, count=132"))))))
+
+(deftest events-firing-truncates-large-result-sets-test
+  (testing "details list truncates after max rows and notes the remainder"
+    (let [rows (mapv (fn [i] {:service (str "svc-" i) :count (+ 100 i)}) (range 10))
+          result {:data {:rows rows :total_count (count rows)}}
+          {:keys [annotations]} (single-alert (build-payload base-rule "firing" result))
+          details (get annotations "breach_details")]
+      (is (str/includes? details "svc-0"))
+      (is (str/includes? details "svc-4"))
+      (is (str/includes? details "and 5 more"))
+      (is (not (str/includes? details "svc-5"))
+          "rows beyond the cap should not appear individually"))))
+
+;; ---------------------------------------------------------
+;; Annotations — metrics firing path
+
+(deftest metrics-firing-includes-series-summary-test
+  (testing "metrics firing payload renders series with name, labels, and last value"
+    (let [rule (assoc base-rule :query_mode "metrics")
+          result {:data {:series [{:id "A" :name "cpu.utilization"
+                                   :labels {"host.name" "node-1"}
+                                   :data [{:timestamp 1 :value 95.5}]}
+                                  {:id "A" :name "cpu.utilization"
+                                   :labels {"host.name" "node-2"}
+                                   :data [{:timestamp 1 :value 91.2}]}]}}
+          {:keys [annotations]} (single-alert (build-payload rule "firing" result))]
+      (is (str/includes? (get annotations "summary") "2 series breached"))
+      (is (str/includes? (get annotations "breach_details") "cpu.utilization"))
+      (is (str/includes? (get annotations "breach_details") "host.name=node-1"))
+      (is (str/includes? (get annotations "breach_details") "95.50")))))
+
+(deftest metrics-alert-target-narrows-summary-test
+  (testing "alert_target restricts the summary to the targeted ref"
+    (let [rule (assoc base-rule
+                      :query_mode "metrics"
+                      :alert_target "B")
+          result {:data {:series [{:id "A" :name "http.requests"
+                                   :labels {} :data [{:timestamp 1 :value 1000}]}
+                                  {:id "B" :name "http.errors"
+                                   :labels {} :data [{:timestamp 1 :value 50}]}]}}
+          {:keys [annotations]} (single-alert (build-payload rule "firing" result))]
+      (is (str/includes? (get annotations "summary") "1 series breached"))
+      (is (str/includes? (get annotations "breach_details") "http.errors"))
+      (is (not (str/includes? (get annotations "breach_details") "http.requests"))))))
+
+(deftest metrics-firing-with-empty-data-degrades-gracefully-test
+  (testing "metrics result with all-empty series produces no summary annotations"
+    (let [rule (assoc base-rule :query_mode "metrics")
+          result {:data {:series [{:id "A" :name "m" :labels {} :data []}]}}
+          {:keys [annotations]} (single-alert (build-payload rule "firing" result))]
+      (is (nil? (get annotations "summary")))
+      (is (nil? (get annotations "breach_details")))
+      (is (= "Errors exceed threshold" (get annotations "description"))
+          "description survives even when result has no usable breach data"))))
+
+;; ---------------------------------------------------------
+;; Annotations — no_result + resolved + nil-result paths
+
+(deftest no-result-firing-uses-fixed-summary-test
+  (testing "no_result mode firing has a deterministic summary, not row-derived"
+    (let [rule (assoc base-rule :alert_on "no_result")
+          ;; Empty result is the firing condition for no_result mode
+          result {:data {:rows [] :total_count 0}}
+          {:keys [annotations]} (single-alert (build-payload rule "firing" result))]
+      (is (str/includes? (get annotations "summary") "no results")
+          "summary should explain the absence-detection trigger")
+      (is (nil? (get annotations "breach_details"))
+          "no rows means no per-row breakdown to render"))))
+
+(deftest resolved-status-omits-breach-context-test
+  (testing "resolved status sets endsAt and skips breach details"
+    (let [{:keys [annotations endsAt]} (single-alert (build-payload base-rule "resolved" nil))]
+      (is (= "Errors exceed threshold" (get annotations "description")))
+      (is (nil? (get annotations "summary")))
+      (is (nil? (get annotations "breach_details")))
+      (is (not= "0001-01-01T00:00:00Z" endsAt)
+          "resolved alerts should carry a real RFC3339 endsAt"))))
+
+(deftest nil-result-on-firing-keeps-payload-valid-test
+  (testing "evaluation error path: nil result still yields a deliverable payload"
+    (let [{:keys [labels annotations startsAt fingerprint]}
+          (single-alert (build-payload base-rule "firing" nil))]
+      (is (= "High error rate" (get labels "alertname")))
+      (is (some? startsAt))
+      (is (some? fingerprint))
+      (is (nil? (get annotations "summary"))
+          "no result -> no summary, but description still rides along")
+      (is (= "Errors exceed threshold" (get annotations "description"))))))
+
+;; ---------------------------------------------------------
+;; Rich Comment
+(comment
+
+  (require '[clojure.test :refer [run-tests]])
+  (run-tests 'o11ylite.alert-rule.notify-test)
+
+  #_()) ; End of rich comment block
+;; ---------------------------------------------------------


### PR DESCRIPTION
## Why

Right now an alert webhook payload looks like this once a downstream Discord/Alertmanager-style receiver renders it:

```
Alerts Resolved:
Labels:
 - alertname = mk2: StatefulSet pods not ready
 - source = o11ylite
Annotations:
 - description = A StatefulSet has fewer ready pods than desired — sustained over the eval window.
```

Useful enough to know *that* something happened, useless for knowing **what** breached. Which namespace? Which statefulset? Which node? You have to context-switch back into o11ylite and re-run the query yourself.

The query result is already computed by the eval engine — we just throw it away after deciding `:firing` / `:ok`. This PR threads it through to the webhook builder and turns it into actionable context.

## What changes

`evaluate-rule` now returns `{:state, :error, :result}` instead of `{:state, :error}`. The eval-and-notify cycle hands `result` to `notify/maybe-send-webhook!`, which mines it for breach context.

**Labels** — kept minimal on purpose. Alertmanager labels are routing/grouping keys, not display payload, and rule-shape fields like `query_mode` / `alert_on` / `alert_target` aren't useful for routing. Stuffing them in just pollutes the namespace and creates a stable contract we'd regret. User-defined labels are a planned follow-up.

| Label       | Always | Description                  |
|-------------|--------|------------------------------|
| `alertname` | yes    | The rule name (unchanged)    |
| `source`    | yes    | Constant `o11ylite` (unchanged) |

**Annotations** (high-cardinality, the human-readable "why"):

| Annotation        | When               | Description                                                       |
|-------------------|--------------------|-------------------------------------------------------------------|
| `description`     | unchanged          | The rule's stored description                                     |
| `summary`         | firing             | One-line breach summary                                           |
| `breach_details`  | firing w/ rows     | Multi-line list of up to 5 breaching rows/series + `... and N more` |
| `eval_window_ms`  | always             | Exact ms for receivers that prefer machine-readable                |

For **events** rules the summary/details come from the rows (group_by columns + aggregation values). For **metrics** rules they come from the breaching series — `metric.name{label=value,…}=last_value` — narrowed by `alert_target` if set.

**Scope note — `no_result` alerts.** This PR explicitly targets the positive-breach case. For `alert_on: "no_result"` firing the summary is a fixed string explaining the absence-detection trigger, and `breach_details` is omitted (there are no rows to enumerate). Making no_result payloads truly informative requires tracking *expected* groups (static list, baseline, or stripping the threshold and re-querying) — that's a separate piece of engineering and will get its own issue.

Resolved alerts intentionally carry only `description` because breach context would describe the *previous* firing window, not the current `ok` state.

## Sample payloads

Generated from the new `-build-payload` against synthetic data — see `backend/test/o11ylite/alert_rule/notify_test.clj` for the full coverage.

**Events firing — the StatefulSet alert from the example above:**

```json
{
  "labels": {
    "alertname": "mk2: StatefulSet pods not ready",
    "source": "o11ylite"
  },
  "annotations": {
    "description": "A StatefulSet has fewer ready pods than desired — sustained over the eval window.",
    "summary": "2 group(s) breached: namespace=media, statefulset=jellyfin, ready=1, desired=2 | namespace=infra, statefulset=redis, ready=0, desired=1",
    "breach_details": "namespace=media, statefulset=jellyfin, ready=1, desired=2\nnamespace=infra, statefulset=redis, ready=0, desired=1",
    "eval_window_ms": "300000"
  },
  "startsAt": "2024-05-01T11:20:00Z",
  "endsAt": "0001-01-01T00:00:00Z",
  "generatorURL": "",
  "fingerprint": "00000000720d4ac1"
}
```

**Metrics firing with `alert_target=A`:**

```json
{
  "labels": {
    "alertname": "CPU pressure",
    "source": "o11ylite"
  },
  "annotations": {
    "description": "Per-node CPU utilization sustained above 90%",
    "summary": "2 series breached: k8s.node.cpu.utilization{k8s.node.name=mk2-node-1}=0.9400 | k8s.node.cpu.utilization{k8s.node.name=mk2-node-2}=0.9100",
    "breach_details": "k8s.node.cpu.utilization{k8s.node.name=mk2-node-1}=0.9400\nk8s.node.cpu.utilization{k8s.node.name=mk2-node-2}=0.9100",
    "eval_window_ms": "600000"
  }
}
```

## Tests

- New pure-function unit suite for `-build-payload`: 9 tests / 38 assertions covering minimal labels, events firing, metrics firing, `alert_target` narrowing, no_result firing, resolved status, and the nil-result fallback path.
- Existing integration tests (`alert_rule_eval_test`) still pass — `:result` was added as an additional return key, no shape change to existing keys.
- `make format-check` clean.

```
backend $ clojure -M:test/env:test/run --focus o11ylite.alert-rule.notify-test
9 tests, 38 assertions, 0 failures.
```

## Compatibility

The Alertmanager v4 webhook contract is preserved — labels and annotations are open string maps, so existing receivers ignore the new keys harmlessly. Any receiver that already keys off `alertname` keeps working unchanged.
