### PR TITLE
fix(frontend): order tooltip rows by value desc and make legend foldable

### DIFF
--- a/frontend/src/components/ui/chart.test.tsx
+++ b/frontend/src/components/ui/chart.test.tsx
@@ -1,0 +1,202 @@
+import { render, fireEvent } from "@testing-library/react"
+import { describe, it, expect } from "vitest"
+import * as React from "react"
+
+import {
+  ChartContext,
+  ChartLegendContent,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "./chart"
+
+// Helpers ---------------------------------------------------------------
+
+const config: ChartConfig = {
+  alpha: { label: "Alpha", color: "#ff0000" },
+  beta: { label: "Beta", color: "#00ff00" },
+  gamma: { label: "Gamma", color: "#0000ff" },
+  delta: { label: "Delta", color: "#ffff00" },
+}
+
+// Lightweight ChartContext provider — both ChartTooltipContent and
+// ChartLegendContent only call useChart() to read config; we don't need
+// the full ChartContainer + ResponsiveContainer + SVG plumbing for unit
+// tests, and ResponsiveContainer doesn't render in jsdom anyway.
+function withChart(node: React.ReactNode) {
+  return render(
+    <ChartContext.Provider value={{ config }}>{node}</ChartContext.Provider>,
+  )
+}
+
+// ChartTooltipContent ---------------------------------------------------
+
+describe("ChartTooltipContent", () => {
+  it("sorts visible series by value descending", () => {
+    const payload = [
+      { name: "alpha", dataKey: "alpha", value: 10, color: "#ff0000", payload: {} },
+      { name: "beta", dataKey: "beta", value: 100, color: "#00ff00", payload: {} },
+      { name: "gamma", dataKey: "gamma", value: 50, color: "#0000ff", payload: {} },
+    ]
+
+    const { container } = withChart(
+      <ChartTooltipContent active payload={payload} hideLabel />,
+    )
+
+    const labels = Array.from(
+      container.querySelectorAll("span.text-muted-foreground"),
+    ).map((el) => el.textContent)
+
+    expect(labels).toEqual(["Beta", "Gamma", "Alpha"])
+  })
+
+  it("sinks non-numeric / nullish values to the bottom", () => {
+    // Recharts emits `value: undefined` for gaps in a series — verify our
+    // sort treats those as -Infinity so they sink rather than scrambling
+    // the order.
+    const payload = [
+      { name: "alpha", dataKey: "alpha", value: 10, color: "#ff0000", payload: {} },
+      { name: "beta", dataKey: "beta", value: undefined, color: "#00ff00", payload: {} },
+      { name: "gamma", dataKey: "gamma", value: 50, color: "#0000ff", payload: {} },
+      { name: "delta", dataKey: "delta", value: undefined, color: "#ffff00", payload: {} },
+    ]
+
+    const { container } = withChart(
+      <ChartTooltipContent active payload={payload} hideLabel />,
+    )
+
+    const labels = Array.from(
+      container.querySelectorAll("span.text-muted-foreground"),
+    ).map((el) => el.textContent)
+
+    // Numeric desc first; undefined values last in name order.
+    expect(labels).toEqual(["Gamma", "Alpha", "Beta", "Delta"])
+  })
+
+  it("breaks ties on name for stable ordering", () => {
+    const payload = [
+      { name: "gamma", dataKey: "gamma", value: 5, color: "#0000ff", payload: {} },
+      { name: "alpha", dataKey: "alpha", value: 5, color: "#ff0000", payload: {} },
+      { name: "beta", dataKey: "beta", value: 5, color: "#00ff00", payload: {} },
+    ]
+
+    const { container } = withChart(
+      <ChartTooltipContent active payload={payload} hideLabel />,
+    )
+
+    const labels = Array.from(
+      container.querySelectorAll("span.text-muted-foreground"),
+    ).map((el) => el.textContent)
+
+    expect(labels).toEqual(["Alpha", "Beta", "Gamma"])
+  })
+
+  it("uses the formatter prop (covers TimeSeriesChart's render path)", () => {
+    const payload = [
+      { name: "alpha", dataKey: "alpha", value: 10, color: "#ff0000", payload: {} },
+      { name: "beta", dataKey: "beta", value: 100, color: "#00ff00", payload: {} },
+      { name: "gamma", dataKey: "gamma", value: 50, color: "#0000ff", payload: {} },
+    ]
+
+    const formatter = (value: unknown, name: unknown) => (
+      <span data-testid="row">{`${String(name)}=${String(value)}`}</span>
+    )
+
+    const { container } = withChart(
+      <ChartTooltipContent
+        active
+        payload={payload}
+        hideLabel
+        formatter={formatter}
+      />,
+    )
+
+    const rows = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-testid='row']"),
+    ).map((el) => el.textContent)
+
+    // Sort happens before formatter is applied.
+    expect(rows).toEqual(["beta=100", "gamma=50", "alpha=10"])
+  })
+})
+
+// ChartLegendContent ----------------------------------------------------
+
+describe("ChartLegendContent", () => {
+  it("renders inline when at or below the collapse threshold", () => {
+    // 8 series — exactly at the threshold, no toggle expected.
+    const payload = Array.from({ length: 8 }, (_, i) => ({
+      value: `series-${i}`,
+      dataKey: `series-${i}`,
+      type: "line" as const,
+      color: "#ff0000",
+    }))
+
+    const { container, queryByRole } = withChart(
+      <ChartLegendContent payload={payload} />,
+    )
+
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper?.className).toContain("flex-wrap")
+    // No expanded styling since not collapsible.
+    expect(wrapper?.className).not.toContain("max-h-24")
+    // No toggle button.
+    expect(queryByRole("button")).toBeNull()
+    // All swatches render.
+    const swatches = wrapper.querySelectorAll("div[style*='background']")
+    expect(swatches.length).toBe(8)
+  })
+
+  it("collapses long legends with a 'Show all (N)' toggle", () => {
+    // 16 series mirrors the bug repro (DuckDB memory by tag).
+    const payload = Array.from({ length: 16 }, (_, i) => ({
+      value: `series-${i}`,
+      dataKey: `series-${i}`,
+      type: "line" as const,
+      color: "#ff0000",
+    }))
+
+    const { container, getByRole } = withChart(
+      <ChartLegendContent payload={payload} />,
+    )
+
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper?.className).toContain("flex-wrap")
+
+    // Only the first 8 swatches render initially.
+    const swatches = wrapper.querySelectorAll("div[style*='background']")
+    expect(swatches.length).toBe(8)
+
+    // A toggle button is present and reports the total count.
+    const toggle = getByRole("button")
+    expect(toggle.textContent).toContain("Show all (16)")
+    expect(toggle.getAttribute("aria-expanded")).toBe("false")
+  })
+
+  it("shows all series when the toggle is clicked", () => {
+    const payload = Array.from({ length: 16 }, (_, i) => ({
+      value: `series-${i}`,
+      dataKey: `series-${i}`,
+      type: "line" as const,
+      color: "#ff0000",
+    }))
+
+    const { container, getByRole } = withChart(
+      <ChartLegendContent payload={payload} />,
+    )
+
+    const toggle = getByRole("button")
+    fireEvent.click(toggle)
+
+    const wrapper = container.firstChild as HTMLElement
+    // Expanded — all 16 swatches render and the height cap kicks in
+    // so the legend doesn't take over the chart.
+    const swatches = wrapper.querySelectorAll("div[style*='background']")
+    expect(swatches.length).toBe(16)
+    expect(wrapper.className).toContain("max-h-24")
+    expect(wrapper.className).toContain("overflow-y-auto")
+
+    // Toggle now collapses again.
+    expect(toggle.textContent).toContain("Show less")
+    expect(toggle.getAttribute("aria-expanded")).toBe("true")
+  })
+})

--- a/frontend/src/components/ui/chart.tsx
+++ b/frontend/src/components/ui/chart.tsx
@@ -169,6 +169,21 @@ function ChartTooltipContent({
 
   const nestLabel = payload.length === 1 && indicator !== "dot"
 
+  // Sort visible items by numeric value descending so the largest series
+  // appears at the top of the hover panel. Non-numeric / nullish values
+  // sink to the bottom; ties break on name for a stable ordering.
+  const sortedPayload = payload
+    .filter((item) => item.type !== "none")
+    .slice()
+    .sort((a, b) => {
+      const av = typeof a.value === "number" ? a.value : -Infinity
+      const bv = typeof b.value === "number" ? b.value : -Infinity
+      if (bv !== av) return bv - av
+      const an = `${a.name ?? a.dataKey ?? ""}`
+      const bn = `${b.name ?? b.dataKey ?? ""}`
+      return an.localeCompare(bn)
+    })
+
   return (
     <div
       className={cn(
@@ -178,8 +193,7 @@ function ChartTooltipContent({
     >
       {!nestLabel ? tooltipLabel : null}
       <div className="grid gap-1.5">
-        {payload
-          .filter((item) => item.type !== "none")
+        {sortedPayload
           .map((item, index) => {
             const key = `${nameKey || item.name || item.dataKey || "value"}`
             const itemConfig = getPayloadConfigFromPayload(config, item, key)
@@ -251,6 +265,12 @@ function ChartTooltipContent({
 
 const ChartLegend = RechartsPrimitive.Legend
 
+// When the legend has more than this many series, collapse by default and
+// show a "Show all (N)" toggle. Tuned so the typical 8-series JVM-pool
+// chart stays inline; high-cardinality charts (DuckDB memory by tag,
+// HTTP routes, etc.) get the toggle.
+const LEGEND_COLLAPSE_THRESHOLD = 8
+
 function ChartLegendContent({
   className,
   hideIcon = false,
@@ -263,46 +283,71 @@ function ChartLegendContent({
     nameKey?: string
   }) {
   const { config } = useChart()
+  const [expanded, setExpanded] = React.useState(false)
 
-  if (!payload?.length) {
+  const visibleItems = React.useMemo(
+    () => payload?.filter((item) => item.type !== "none") ?? [],
+    [payload],
+  )
+
+  if (!visibleItems.length) {
     return null
   }
+
+  const isCollapsible = visibleItems.length > LEGEND_COLLAPSE_THRESHOLD
+  const shownItems =
+    isCollapsible && !expanded
+      ? visibleItems.slice(0, LEGEND_COLLAPSE_THRESHOLD)
+      : visibleItems
+  const hiddenCount = visibleItems.length - shownItems.length
 
   return (
     <div
       className={cn(
-        "flex items-center justify-center gap-4",
+        "flex flex-wrap items-center justify-center gap-x-4 gap-y-1",
+        // Cap the expanded legend so a 30+ series chart can't push the
+        // plot area off-screen; the user can scroll within the legend.
+        expanded && "max-h-24 overflow-y-auto",
         verticalAlign === "top" ? "pb-3" : "pt-3",
-        className
+        className,
       )}
     >
-      {payload
-        .filter((item) => item.type !== "none")
-        .map((item) => {
-          const key = `${nameKey || item.dataKey || "value"}`
-          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+      {shownItems.map((item) => {
+        const key = `${nameKey || item.dataKey || "value"}`
+        const itemConfig = getPayloadConfigFromPayload(config, item, key)
 
-          return (
-            <div
-              key={item.value}
-              className={cn(
-                "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3"
-              )}
-            >
-              {itemConfig?.icon && !hideIcon ? (
-                <itemConfig.icon />
-              ) : (
-                <div
-                  className="h-2 w-2 shrink-0 rounded-[2px]"
-                  style={{
-                    backgroundColor: item.color,
-                  }}
-                />
-              )}
-              {itemConfig?.label}
-            </div>
-          )
-        })}
+        return (
+          <div
+            key={item.value}
+            className={cn(
+              "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3",
+            )}
+          >
+            {itemConfig?.icon && !hideIcon ? (
+              <itemConfig.icon />
+            ) : (
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{
+                  backgroundColor: item.color,
+                }}
+              />
+            )}
+            {itemConfig?.label}
+          </div>
+        )
+      })}
+      {isCollapsible && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="text-muted-foreground hover:text-foreground cursor-pointer text-xs underline-offset-2 hover:underline"
+          aria-expanded={expanded}
+        >
+          {expanded ? "Show less" : `Show all (${visibleItems.length})`}
+          {!expanded && hiddenCount > 0 ? ` · +${hiddenCount} more` : ""}
+        </button>
+      )}
     </div>
   )
 }
@@ -348,6 +393,7 @@ function getPayloadConfigFromPayload(
 
 export {
   ChartContainer,
+  ChartContext,
   ChartTooltip,
   ChartTooltipContent,
   ChartLegend,


### PR DESCRIPTION
## Problem

Two UX bugs in the time-series chart surfaced when a query produces many series — e.g. `o11ylite.duckdb.memory` grouped by `attr.o11ylite.duckdb.memory.type` yields 16 series:

1. **Legend was clipped.** The legend's flex container had no `flex-wrap`, so on a chart with 16 series only the first 2 swatches fit on screen and the rest were hidden behind the chart's right edge.
2. **Tooltip rows were in arbitrary order.** Hover values rendered in series-declaration order, interleaving 71 MB entries with 0 B entries. With 16 rows you couldn't tell at a glance which series was actually large at the hovered timestamp.

## Fix

Both fixes live in `frontend/src/components/ui/chart.tsx`.

### Tooltip — sort rows by value descending

`ChartTooltipContent` now sorts the payload before rendering:

- Numeric values descending (largest at top).
- Non-numeric / `undefined` values (gaps) sink to the bottom.
- Ties break on name for a stable, deterministic ordering.

The sort happens before the `formatter` prop runs, so `TimeSeriesChart`'s custom row renderer benefits without changes.

### Legend — wrap, then collapse when there are many series

`ChartLegendContent` now:

- Wraps onto multiple rows (`flex-wrap`) so 8-ish series stay readable.
- When the legend would have more than **8** entries (`LEGEND_COLLAPSE_THRESHOLD`), it collapses by default to the first 8 and shows a `Show all (N) · +K more` toggle.
- When expanded, the legend is capped at `max-h-24 overflow-y-auto` so a 30+ series chart can't push the plot area off-screen — the user scrolls within the legend instead.
- The toggle is a real `<button>` with `aria-expanded`.

`ChartContext` is exported so unit tests can drive these subcomponents directly without the full `ChartContainer` + `ResponsiveContainer` stack (which doesn't lay out in jsdom).

## Tests

7 new unit tests in `frontend/src/components/ui/chart.test.tsx`:

**ChartTooltipContent**
- Sorts visible series by value descending
- Sinks `undefined` values to the bottom (gap-friendly)
- Breaks ties on name for stable ordering
- Sort happens before the `formatter` prop is applied (covers `TimeSeriesChart`'s render path)

**ChartLegendContent**
- Renders inline (no toggle, no height cap) at or below the threshold
- Collapses to first 8 + `Show all (N)` toggle above the threshold
- Toggle expands to all entries with the height cap applied

`npm test` → 49/49 passing. `npm run lint` and `npx tsc -b --noEmit` clean.

## Manual verification

Drove the live dev stack with playwright, querying `o11ylite.duckdb.memory` grouped by `memory.type` (the same 16-category breakdown shown in the bug report):

- Collapsed legend reads `Show all (16) · +8 more`.
- Clicking the toggle expands to all 16 swatches; classes flip to `max-h-24 overflow-y-auto`.
- Hover tooltip: top → bottom is `in_memory_table 40.56 MB → base_table 18.35 MB → art_index 5.51 MB → transaction 2.1 MB → allocator 385 KB`, then all `0 B` entries alphabetically.

Screenshots delivered separately in chat.
