### PR TITLE
feat(frontend): fold attribute namespaces in events side panel

### DIFF
--- a/frontend/src/components/events-side-panel.tsx
+++ b/frontend/src/components/events-side-panel.tsx
@@ -1,7 +1,12 @@
 import { useState } from "react"
-import { MoreVertical } from "lucide-react"
+import { ChevronRight, MoreVertical } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -11,24 +16,56 @@ import {
 import { FieldTypeBadge } from "@/components/field-type-badge"
 import { useEventFieldsQuery } from "@/hooks/use-event-fields-query"
 import { useEventQueryActions } from "@/hooks/use-event-query-actions"
+import { groupAttributeFields } from "@/lib/group-fields"
+import type { Field } from "@/types"
+
+function FieldRow({
+  field,
+  onAddExistsFilter,
+}: {
+  field: Field
+  onAddExistsFilter: (name: string) => void
+}) {
+  return (
+    <div className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent group">
+      <div className="flex items-center gap-2 flex-1 min-w-0">
+        <FieldTypeBadge type={field.type} />
+        <span className="text-xs text-muted-foreground group-hover:text-foreground truncate">
+          {field.name}
+        </span>
+      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+            aria-label={`Actions for ${field.name}`}
+          >
+            <MoreVertical className="h-3 w-3" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => onAddExistsFilter(field.name)}>
+            Filter where field exists
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}
 
 export function EventsSidePanel() {
   const { fields } = useEventFieldsQuery()
   const [searchQuery, setSearchQuery] = useState("")
   const { addExistsFilter } = useEventQueryActions()
 
-  const filteredFields = fields
-    .filter(
-      (field) =>
-        !searchQuery ||
-        field.name.toLowerCase().includes(searchQuery.toLowerCase())
-    )
-    .sort((a, b) => {
-      const aIsAttr = a.name.startsWith("attr.")
-      const bIsAttr = b.name.startsWith("attr.")
-      if (aIsAttr !== bIsAttr) return aIsAttr ? 1 : -1
-      return a.name.localeCompare(b.name)
-    })
+  const isSearching = searchQuery.length > 0
+  const matchesSearch = (name: string) =>
+    !isSearching || name.toLowerCase().includes(searchQuery.toLowerCase())
+
+  const filteredFields = fields.filter((f) => matchesSearch(f.name))
+  const { ungrouped, groups } = groupAttributeFields(filteredFields)
 
   return (
     <div className="space-y-2">
@@ -40,37 +77,71 @@ export function EventsSidePanel() {
         onChange={(e) => setSearchQuery(e.target.value)}
       />
       <div className="space-y-0.5">
-        {filteredFields.map((field) => (
-          <div
+        {ungrouped.map((field) => (
+          <FieldRow
             key={field.name}
-            className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent group"
-          >
-            <div className="flex items-center gap-2 flex-1 min-w-0">
-              <FieldTypeBadge type={field.type} />
-              <span className="text-xs text-muted-foreground group-hover:text-foreground truncate">
-                {field.name}
-              </span>
-            </div>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
-                  aria-label={`Actions for ${field.name}`}
-                >
-                  <MoreVertical className="h-3 w-3" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => addExistsFilter(field.name)}>
-                  Filter where field exists
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+            field={field}
+            onAddExistsFilter={addExistsFilter}
+          />
+        ))}
+        {groups.map((group) => (
+          <FieldGroup
+            key={group.prefix}
+            prefix={group.prefix}
+            fields={group.fields}
+            // While searching, force-open every surviving group so matching
+            // children are visible without an extra click. Otherwise default
+            // to collapsed — that's the whole point of the grouping.
+            forceOpen={isSearching}
+            onAddExistsFilter={addExistsFilter}
+          />
         ))}
       </div>
     </div>
+  )
+}
+
+function FieldGroup({
+  prefix,
+  fields,
+  forceOpen,
+  onAddExistsFilter,
+}: {
+  prefix: string
+  fields: Field[]
+  forceOpen: boolean
+  onAddExistsFilter: (name: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const isOpen = forceOpen || open
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setOpen}>
+      <CollapsibleTrigger
+        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent group"
+        aria-label={`Toggle ${prefix} attributes`}
+      >
+        <ChevronRight
+          className={`h-3 w-3 shrink-0 text-muted-foreground transition-transform ${isOpen ? "rotate-90" : ""}`}
+        />
+        <span className="text-xs font-medium text-foreground truncate flex-1 min-w-0">
+          {prefix}
+        </span>
+        <span className="text-[10px] text-muted-foreground shrink-0">
+          {fields.length}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="ml-4 space-y-0.5 border-l border-border pl-2">
+          {fields.map((field) => (
+            <FieldRow
+              key={field.name}
+              field={field}
+              onAddExistsFilter={onAddExistsFilter}
+            />
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
   )
 }

--- a/frontend/src/lib/group-fields.test.ts
+++ b/frontend/src/lib/group-fields.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest"
+import type { Field } from "@/types"
+import { groupAttributeFields } from "./group-fields"
+
+const f = (name: string): Field => ({ name, type: "string" })
+
+describe("groupAttributeFields", () => {
+  it("keeps non-attr fields ungrouped, sorted alphabetically", () => {
+    const result = groupAttributeFields([
+      f("timestamp"),
+      f("body"),
+      f("event.name"),
+      f("service.name"),
+    ])
+    expect(result.groups).toEqual([])
+    expect(result.ungrouped.map((x) => x.name)).toEqual([
+      "body",
+      "event.name",
+      "service.name",
+      "timestamp",
+    ])
+  })
+
+  it("groups attr.<ns>.* with 2+ siblings under attr.<ns>", () => {
+    const result = groupAttributeFields([
+      f("attr.buildkite.build.id"),
+      f("attr.buildkite.pipeline.slug"),
+      f("attr.buildkite.organization.slug"),
+      f("attr.host.name"),
+      f("attr.host.id"),
+      f("event.name"),
+    ])
+
+    expect(result.ungrouped.map((x) => x.name)).toEqual(["event.name"])
+    expect(result.groups).toHaveLength(2)
+
+    const [bk, host] = result.groups
+    expect(bk.prefix).toBe("attr.buildkite")
+    expect(bk.fields.map((x) => x.name)).toEqual([
+      "attr.buildkite.build.id",
+      "attr.buildkite.organization.slug",
+      "attr.buildkite.pipeline.slug",
+    ])
+    expect(host.prefix).toBe("attr.host")
+    expect(host.fields.map((x) => x.name)).toEqual([
+      "attr.host.id",
+      "attr.host.name",
+    ])
+  })
+
+  it("leaves singleton attr.<ns>.x ungrouped (no folding for one item)", () => {
+    const result = groupAttributeFields([
+      f("attr.region.us"),
+      f("attr.host.id"),
+      f("attr.host.name"),
+    ])
+    expect(result.ungrouped.map((x) => x.name)).toEqual(["attr.region.us"])
+    expect(result.groups).toHaveLength(1)
+    expect(result.groups[0].prefix).toBe("attr.host")
+  })
+
+  it("treats attr.foo (no second segment) as ungrouped", () => {
+    const result = groupAttributeFields([
+      f("attr.foo"),
+      f("attr.bar"),
+      f("attr.host.id"),
+      f("attr.host.name"),
+    ])
+    expect(result.ungrouped.map((x) => x.name)).toEqual([
+      "attr.bar",
+      "attr.foo",
+    ])
+    expect(result.groups.map((g) => g.prefix)).toEqual(["attr.host"])
+  })
+
+  it("sorts groups alphabetically by prefix", () => {
+    const result = groupAttributeFields([
+      f("attr.zoo.a"),
+      f("attr.zoo.b"),
+      f("attr.alpha.x"),
+      f("attr.alpha.y"),
+      f("attr.middle.p"),
+      f("attr.middle.q"),
+    ])
+    expect(result.groups.map((g) => g.prefix)).toEqual([
+      "attr.alpha",
+      "attr.middle",
+      "attr.zoo",
+    ])
+  })
+
+  it("returns empty result for empty input", () => {
+    expect(groupAttributeFields([])).toEqual({ ungrouped: [], groups: [] })
+  })
+})

--- a/frontend/src/lib/group-fields.ts
+++ b/frontend/src/lib/group-fields.ts
@@ -1,0 +1,75 @@
+// ---
+// Group OTel-style attribute fields by their semantic-convention namespace.
+//
+// OTel attribute names use dotted namespaces (e.g. `attr.buildkite.build.id`,
+// `attr.host.name`). When a panel lists many of these, folding them by the
+// shared namespace prefix makes the panel scannable.
+//
+// The grouping rule:
+//   * Non-`attr.*` fields stay flat.
+//   * `attr.<ns>.*` fields with **2+ siblings** sharing the same `<ns>` are
+//     pulled into a group keyed by `attr.<ns>` (e.g. group "attr.buildkite"
+//     contains `attr.buildkite.build.id`, `attr.buildkite.pipeline.slug`, ...).
+//   * Singletons (`attr.foo` or a lone `attr.namespace.bar`) stay flat in the
+//     ungrouped list — wrapping a single item in a collapsible adds noise.
+// ---
+import type { Field } from "@/types"
+
+export interface FieldGroup {
+  /** Group prefix shown as the collapsible header (e.g. `attr.buildkite`). */
+  prefix: string
+  /** Fields belonging to this group, sorted alphabetically by name. */
+  fields: Field[]
+}
+
+export interface GroupedFields {
+  /** Fields rendered flat above the groups, sorted alphabetically. */
+  ungrouped: Field[]
+  /** Collapsible groups, sorted alphabetically by prefix. */
+  groups: FieldGroup[]
+}
+
+/**
+ * Extract the `attr.<ns>` namespace key from a field name, or `null` if the
+ * field is not a multi-segment attribute. `attr.foo` (only one segment after
+ * `attr.`) returns `null` because there's no namespace to group siblings by.
+ */
+function attrNamespace(name: string): string | null {
+  if (!name.startsWith("attr.")) return null
+  const rest = name.slice("attr.".length)
+  const dotIdx = rest.indexOf(".")
+  if (dotIdx <= 0) return null // `attr.foo` or malformed `attr.`
+  return `attr.${rest.slice(0, dotIdx)}`
+}
+
+export function groupAttributeFields(fields: readonly Field[]): GroupedFields {
+  // First pass: count namespace occurrences so singletons can stay flat.
+  const counts = new Map<string, number>()
+  for (const f of fields) {
+    const ns = attrNamespace(f.name)
+    if (ns) counts.set(ns, (counts.get(ns) ?? 0) + 1)
+  }
+
+  const ungrouped: Field[] = []
+  const grouped = new Map<string, Field[]>()
+  for (const f of fields) {
+    const ns = attrNamespace(f.name)
+    if (ns && (counts.get(ns) ?? 0) >= 2) {
+      const bucket = grouped.get(ns) ?? []
+      bucket.push(f)
+      grouped.set(ns, bucket)
+    } else {
+      ungrouped.push(f)
+    }
+  }
+
+  ungrouped.sort((a, b) => a.name.localeCompare(b.name))
+  const groups: FieldGroup[] = Array.from(grouped.entries())
+    .map(([prefix, fs]) => ({
+      prefix,
+      fields: fs.slice().sort((a, b) => a.name.localeCompare(b.name)),
+    }))
+    .sort((a, b) => a.prefix.localeCompare(b.prefix))
+
+  return { ungrouped, groups }
+}


### PR DESCRIPTION
## What

Per the discussion in #project-o11ylite: when an event source emits
many attributes (e.g. Buildkite CI, with `attr.buildkite.*` having
20+ keys), the right-hand fields panel becomes hard to scan.

OTel semantic conventions encode group structure right in the name —
dotted namespaces like `attr.buildkite.*`, `attr.host.*`, `attr.db.*`.
This PR folds those namespaces into collapsible groups, collapsed by
default.

## Rules

- Non-`attr.*` fields → flat at top, alphabetical (`body`, `event.name`,
  `service.name`, `timestamp`, …).
- `attr.<ns>.*` with **2+ siblings** sharing `<ns>` → collapsed group
  `attr.<ns>` (count badge on the right).
- Singletons (`attr.foo` with no second segment, or a lone
  `attr.namespace.bar` with no siblings) → stay flat. Wrapping a
  one-item collapsible would just add visual noise.
- **Searching auto-expands matching groups** so the user doesn't need
  to click through each one to see results.

On the current dev dataset (150 fields) this collapses to ~18 groups
plus the singletons, instead of one wall of 150 rows.

## Code shape

- `frontend/src/lib/group-fields.ts` — pure helper, 6 unit tests
  (singletons, multi-segment, sort order, empty input, etc.).
- `frontend/src/components/events-side-panel.tsx` — extracts a
  `FieldRow` so it can be reused inside groups; uses the existing
  shadcn `Collapsible` (same pattern as `span-details-panel.tsx`).
- No backend / API changes.

## Verification

- `npm test`: 55 passed (including 6 new `group-fields` tests).
- `npx tsc -b --noEmit`, `npm run lint`: clean.
- Manual: dev stack screenshots in chat (collapsed default, expanded
  group, search auto-expand).

## Follow-ups (separate PRs if desired)

- Apply the same grouping to the metrics side panel (e.g. group
  `http.server.*` / `http.client.*`). Current PR is scoped to events
  attributes since that's what the chat report was about.