### PR TITLE
feat(frontend): always group attr.* under namespace headers

### DIFF
--- a/frontend/src/lib/group-fields.test.ts
+++ b/frontend/src/lib/group-fields.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest"
 import type { Field } from "@/types"
-import { groupAttributeFields } from "./group-fields"
+import {
+  groupAttributeFields,
+  UNNAMESPACED_GROUP,
+} from "./group-fields"
 
 const f = (name: string): Field => ({ name, type: "string" })
 
@@ -21,7 +24,7 @@ describe("groupAttributeFields", () => {
     ])
   })
 
-  it("groups attr.<ns>.* with 2+ siblings under attr.<ns>", () => {
+  it("groups attr.<ns>.* under attr.<ns>, sorted within each group", () => {
     const result = groupAttributeFields([
       f("attr.buildkite.build.id"),
       f("attr.buildkite.pipeline.slug"),
@@ -48,32 +51,55 @@ describe("groupAttributeFields", () => {
     ])
   })
 
-  it("leaves singleton attr.<ns>.x ungrouped (no folding for one item)", () => {
+  it("groups singleton attr.<ns>.x under attr.<ns> (consistent namespace headers)", () => {
     const result = groupAttributeFields([
       f("attr.region.us"),
       f("attr.host.id"),
       f("attr.host.name"),
     ])
-    expect(result.ungrouped.map((x) => x.name)).toEqual(["attr.region.us"])
-    expect(result.groups).toHaveLength(1)
-    expect(result.groups[0].prefix).toBe("attr.host")
+    expect(result.ungrouped).toEqual([])
+    expect(result.groups).toHaveLength(2)
+
+    const [host, region] = result.groups
+    expect(host.prefix).toBe("attr.host")
+    expect(host.fields.map((x) => x.name)).toEqual([
+      "attr.host.id",
+      "attr.host.name",
+    ])
+    expect(region.prefix).toBe("attr.region")
+    expect(region.fields.map((x) => x.name)).toEqual(["attr.region.us"])
   })
 
-  it("treats attr.foo (no second segment) as ungrouped", () => {
+  it("buckets attr.<x> (no namespace) into the (unnamespaced) group", () => {
     const result = groupAttributeFields([
       f("attr.foo"),
       f("attr.bar"),
       f("attr.host.id"),
       f("attr.host.name"),
     ])
-    expect(result.ungrouped.map((x) => x.name)).toEqual([
-      "attr.bar",
-      "attr.foo",
+    expect(result.ungrouped).toEqual([])
+    // (unnamespaced) sorts to the bottom — readers see well-formed
+    // namespaces first, the violation bucket last.
+    expect(result.groups.map((g) => g.prefix)).toEqual([
+      "attr.host",
+      UNNAMESPACED_GROUP,
     ])
-    expect(result.groups.map((g) => g.prefix)).toEqual(["attr.host"])
+    const unns = result.groups.find((g) => g.prefix === UNNAMESPACED_GROUP)!
+    expect(unns.fields.map((x) => x.name)).toEqual(["attr.bar", "attr.foo"])
   })
 
-  it("sorts groups alphabetically by prefix", () => {
+  it("groups even a single unnamespaced attr.x", () => {
+    const result = groupAttributeFields([
+      f("attr.environment"),
+      f("attr.host.id"),
+      f("attr.host.name"),
+    ])
+    expect(result.ungrouped).toEqual([])
+    const unns = result.groups.find((g) => g.prefix === UNNAMESPACED_GROUP)!
+    expect(unns.fields.map((x) => x.name)).toEqual(["attr.environment"])
+  })
+
+  it("sorts groups alphabetically; (unnamespaced) sinks to the bottom", () => {
     const result = groupAttributeFields([
       f("attr.zoo.a"),
       f("attr.zoo.b"),
@@ -81,11 +107,13 @@ describe("groupAttributeFields", () => {
       f("attr.alpha.y"),
       f("attr.middle.p"),
       f("attr.middle.q"),
+      f("attr.orphan"),
     ])
     expect(result.groups.map((g) => g.prefix)).toEqual([
       "attr.alpha",
       "attr.middle",
       "attr.zoo",
+      UNNAMESPACED_GROUP,
     ])
   })
 

--- a/frontend/src/lib/group-fields.ts
+++ b/frontend/src/lib/group-fields.ts
@@ -2,18 +2,25 @@
 // Group OTel-style attribute fields by their semantic-convention namespace.
 //
 // OTel attribute names use dotted namespaces (e.g. `attr.buildkite.build.id`,
-// `attr.host.name`). When a panel lists many of these, folding them by the
-// shared namespace prefix makes the panel scannable.
+// `attr.host.name`). This panel renders every `attr.*` field under a
+// namespace header, advocating the convention that observability attributes
+// should be namespaced.
 //
 // The grouping rule:
-//   * Non-`attr.*` fields stay flat.
-//   * `attr.<ns>.*` fields with **2+ siblings** sharing the same `<ns>` are
-//     pulled into a group keyed by `attr.<ns>` (e.g. group "attr.buildkite"
-//     contains `attr.buildkite.build.id`, `attr.buildkite.pipeline.slug`, ...).
-//   * Singletons (`attr.foo` or a lone `attr.namespace.bar`) stay flat in the
-//     ungrouped list — wrapping a single item in a collapsible adds noise.
+//   * Non-`attr.*` fields stay flat at the top (the OTel core fields like
+//     `body`, `event.name`, `service.name`, `timestamp`).
+//   * `attr.<ns>.*` fields → group keyed by `attr.<ns>`, regardless of how
+//     many siblings exist. Even a singleton `attr.foo.x` lives under an
+//     `attr.foo` header — consistency reinforces the namespace convention.
+//   * `attr.x` with no second segment (no namespace) → bucketed under a
+//     special `(unnamespaced)` group, signalling these attributes violate
+//     the convention. Always sorted to the bottom so dashboard readers
+//     (who can't act on the violation) aren't forced to skim past it.
 // ---
 import type { Field } from "@/types"
+
+/** Header label for `attr.x` fields that have no namespace. */
+export const UNNAMESPACED_GROUP = "(unnamespaced)"
 
 export interface FieldGroup {
   /** Group prefix shown as the collapsible header (e.g. `attr.buildkite`). */
@@ -23,43 +30,43 @@ export interface FieldGroup {
 }
 
 export interface GroupedFields {
-  /** Fields rendered flat above the groups, sorted alphabetically. */
+  /** Non-`attr.*` fields rendered flat above the groups, sorted alphabetically. */
   ungrouped: Field[]
   /** Collapsible groups, sorted alphabetically by prefix. */
   groups: FieldGroup[]
 }
 
 /**
- * Extract the `attr.<ns>` namespace key from a field name, or `null` if the
- * field is not a multi-segment attribute. `attr.foo` (only one segment after
- * `attr.`) returns `null` because there's no namespace to group siblings by.
+ * Classify an `attr.*` field. Returns the group prefix it belongs to, or
+ * `null` if the field is not an attribute (and therefore stays in the
+ * ungrouped flat list).
+ *
+ *   `attr.buildkite.build.id` → `"attr.buildkite"`
+ *   `attr.host.name`          → `"attr.host"`
+ *   `attr.foo`                → UNNAMESPACED_GROUP
+ *   `attr.`                   → UNNAMESPACED_GROUP (defensive)
+ *   `body`                    → null
  */
-function attrNamespace(name: string): string | null {
+function attrGroupKey(name: string): string | null {
   if (!name.startsWith("attr.")) return null
   const rest = name.slice("attr.".length)
   const dotIdx = rest.indexOf(".")
-  if (dotIdx <= 0) return null // `attr.foo` or malformed `attr.`
+  if (dotIdx <= 0) return UNNAMESPACED_GROUP
   return `attr.${rest.slice(0, dotIdx)}`
 }
 
 export function groupAttributeFields(fields: readonly Field[]): GroupedFields {
-  // First pass: count namespace occurrences so singletons can stay flat.
-  const counts = new Map<string, number>()
-  for (const f of fields) {
-    const ns = attrNamespace(f.name)
-    if (ns) counts.set(ns, (counts.get(ns) ?? 0) + 1)
-  }
-
   const ungrouped: Field[] = []
   const grouped = new Map<string, Field[]>()
+
   for (const f of fields) {
-    const ns = attrNamespace(f.name)
-    if (ns && (counts.get(ns) ?? 0) >= 2) {
-      const bucket = grouped.get(ns) ?? []
-      bucket.push(f)
-      grouped.set(ns, bucket)
-    } else {
+    const key = attrGroupKey(f.name)
+    if (key === null) {
       ungrouped.push(f)
+    } else {
+      const bucket = grouped.get(key) ?? []
+      bucket.push(f)
+      grouped.set(key, bucket)
     }
   }
 
@@ -69,7 +76,14 @@ export function groupAttributeFields(fields: readonly Field[]): GroupedFields {
       prefix,
       fields: fs.slice().sort((a, b) => a.name.localeCompare(b.name)),
     }))
-    .sort((a, b) => a.prefix.localeCompare(b.prefix))
+    .sort((a, b) => {
+      // Push the (unnamespaced) bucket to the bottom. Most users are
+      // reading dashboards, not fixing instrumentation — the violation
+      // shouldn't block their scan of the well-formed namespaces.
+      if (a.prefix === UNNAMESPACED_GROUP) return 1
+      if (b.prefix === UNNAMESPACED_GROUP) return -1
+      return a.prefix.localeCompare(b.prefix)
+    })
 
   return { ungrouped, groups }
 }


### PR DESCRIPTION
## What

Follow-up to #103. The side-panel grouping should advocate the OTel
convention that attributes belong in namespaces. Two rule changes,
both about consistency:

### Before
- `attr.<ns>.*` with **2+ siblings** → grouped under `attr.<ns>`.
- Singleton `attr.<ns>.x` → flat in the top block, mixed in with
  `body`, `timestamp`, etc.
- Bare `attr.foo` (no namespace) → also flat in the top block.

### After
- Every `attr.<ns>.*` → grouped under `attr.<ns>`, regardless of
  how many siblings exist. A singleton still gets its namespace
  header (count badge says `1`).
- Bare `attr.<x>` (no namespace) → bucketed under a special
  `(unnamespaced)` group, sorted to the **bottom** so dashboard
  readers (who can't act on the violation) aren't forced to skim
  past it. Instrumenters who care will still find it.
- Non-`attr` fields (`body`, `event.name`, `service.name`,
  `timestamp`) still render flat at the top — those are OTel core
  fields, not attributes.

## Why

The UI now constantly reinforces "observability attributes should be
namespaced." When a user looks at their own data, every `attr.*`
shows up under a namespace header; an unnamespaced attribute lands
in a bucket that names what's wrong, sitting at the bottom of the
group list where it's discoverable but non-intrusive.

## Resulting panel shape

```
body
event.name
service.name
timestamp
─────
attr.buildkite/        (12)
attr.foo/              (1)   ← attr.foo.x — even singletons get a header
attr.host/             (4)
(unnamespaced)/        (3)   ← attr.environment, attr.region, attr.tier
```

## Code shape

- `frontend/src/lib/group-fields.ts` — drop the `≥2 siblings`
  threshold; `attr.x` (no second segment) now returns the special
  `UNNAMESPACED_GROUP` key instead of `null`. The group sort has a
  small explicit clause to push the bucket to the end.
- `frontend/src/lib/group-fields.test.ts` — 7 tests now (was 6),
  covering the two rule changes plus an explicit test that a single
  unnamespaced attribute still gets the bucket, and that
  `(unnamespaced)` lands at the bottom of the groups list.
- No changes to `events-side-panel.tsx` — the rendering treats every
  group identically, so all the new behaviour comes through the helper.

## Verification

- `npm test --run`: 56 passed (was 55, +1 new test for single-orphan
  bucket).
- `npx tsc -b --noEmit`, `npm run lint`: clean.