### PR TITLE
fix(frontend): persist System submenu open state across navigations

### DIFF
--- a/frontend/src/components/app-sidebar.test.tsx
+++ b/frontend/src/components/app-sidebar.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, act } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import * as React from "react"
+
+// ============================================================================
+// Inertia mock — usePage().url controls the active route in the sidebar.
+// We expose a mutable holder so individual tests can override the URL before
+// rendering.
+// ============================================================================
+
+const inertiaState = { url: "/explore" }
+
+vi.mock("@inertiajs/react", () => ({
+  usePage: () => ({ url: inertiaState.url, props: {} }),
+  Link: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode
+    href: string
+  }) => React.createElement("a", { href }, children),
+}))
+
+// Import after mocks are set up.
+const { AppSidebar } = await import("./app-sidebar")
+const { SidebarProvider } = await import("./ui/sidebar")
+
+const STORAGE_KEY = "o11ylite.sidebar.system-open"
+
+function renderSidebar() {
+  return render(
+    <SidebarProvider>
+      <AppSidebar />
+    </SidebarProvider>
+  )
+}
+
+// The Collapsible trigger renders the visible "System" toggle. There are
+// other "System" strings on the page (group label, tooltip), so scope to the
+// button role for the trigger.
+function getSystemTrigger() {
+  return screen.getByRole("button", { name: /^system$/i })
+}
+
+describe("AppSidebar — System submenu persistence", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    inertiaState.url = "/explore"
+  })
+
+  it("defaults to closed on non-system routes when no stored state exists", () => {
+    renderSidebar()
+    expect(getSystemTrigger()).toHaveAttribute("aria-expanded", "false")
+  })
+
+  it("restores open state from localStorage across remounts", () => {
+    window.localStorage.setItem(STORAGE_KEY, "true")
+
+    renderSidebar()
+
+    expect(getSystemTrigger()).toHaveAttribute("aria-expanded", "true")
+  })
+
+  it("persists user toggling to localStorage", async () => {
+    const user = userEvent.setup()
+    renderSidebar()
+
+    expect(getSystemTrigger()).toHaveAttribute("aria-expanded", "false")
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("false")
+
+    await user.click(getSystemTrigger())
+
+    expect(getSystemTrigger()).toHaveAttribute("aria-expanded", "true")
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("true")
+  })
+
+  it("forces the submenu open when navigating to a /system/* route", () => {
+    inertiaState.url = "/system/api-keys"
+    window.localStorage.setItem(STORAGE_KEY, "false")
+
+    renderSidebar()
+
+    // Stored state says "closed" but the active route is under /system, so
+    // the submenu should still be open to reveal the active item.
+    expect(getSystemTrigger()).toHaveAttribute("aria-expanded", "true")
+  })
+
+  it("does not overwrite stored 'true' when the user lands on a /system/* route", () => {
+    // Regression guard: forcing open on system routes is a *display* override,
+    // not a write. The user's persisted preference (here: open) must survive.
+    window.localStorage.setItem(STORAGE_KEY, "true")
+    inertiaState.url = "/system/settings"
+
+    renderSidebar()
+
+    expect(getSystemTrigger()).toHaveAttribute("aria-expanded", "true")
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("true")
+  })
+})
+
+// Silence "act(...) warnings" from radix-ui's collapsible animation that
+// settles after our assertions complete.
+void act

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -36,6 +36,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
+import { useLocalStorage } from "@/hooks/use-local-storage"
 import type { AuthSharedData } from "@/types"
 
 type NavItem = {
@@ -72,6 +73,19 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { url, props: pageProps } = usePage()
   const auth = (pageProps as { auth?: AuthSharedData }).auth
   const user = auth?.user
+
+  // Persist the System submenu open/closed state across page navigations and
+  // reloads. When the current route matches any system item, force the menu
+  // open so the active item is always visible (e.g. deep-linking into
+  // /system/api-keys).
+  const isOnSystemRoute = systemItems.some(
+    (item) => url === item.url || url.startsWith(item.url + "/")
+  )
+  const [systemOpenStored, setSystemOpenStored] = useLocalStorage(
+    "o11ylite.sidebar.system-open",
+    false
+  )
+  const systemOpen = isOnSystemRoute || systemOpenStored
 
   return (
     <Sidebar {...props}>
@@ -118,7 +132,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarGroup>
           <SidebarGroupLabel>System</SidebarGroupLabel>
           <SidebarMenu>
-            <Collapsible defaultOpen={false} className="group/collapsible">
+            <Collapsible
+              open={systemOpen}
+              onOpenChange={setSystemOpenStored}
+              className="group/collapsible"
+            >
               <SidebarMenuItem>
                 <CollapsibleTrigger asChild>
                   <SidebarMenuButton tooltip="System">


### PR DESCRIPTION
## Problem

The "System" collapsible submenu in the left sidebar resets to the closed
state on every page navigation and every browser refresh, even when the
user is actively browsing a `/system/*` route. This makes it tedious to
move between System pages — each navigation hides the menu the user just
opened.

## Root cause

`app-sidebar.tsx` mounted the radix `<Collapsible>` with `defaultOpen={false}`
(uncontrolled). Inertia re-renders the persistent layout on every page
visit, which re-mounts the sidebar and the Collapsible falls back to its
default — closed.

## Fix

Convert the Collapsible to controlled (`open` + `onOpenChange`) and back
it with the existing `useLocalStorage` hook under the key
`o11ylite.sidebar.system-open`. The sidebar's main rail collapse already
uses localStorage for the same reason (see `components/ui/sidebar.tsx`),
so this stays consistent with the existing pattern in the codebase.

Additionally, the submenu is forced open whenever the current URL
matches any item in the `systemItems` list (so deep links like
`/system/api-keys` reveal the active item from a fresh load). The route
check is derived from `systemItems` rather than hardcoded to `/system/*`,
so adding or renaming a system item doesn't require a parallel update
here.

The force-open is a *display* override — it doesn't write to
localStorage, so the user's preference is preserved when they navigate
away.

## Tests

Added `frontend/src/components/app-sidebar.test.tsx` with 5 cases:

- Defaults to closed on non-system routes with no stored state.
- Restores open state from localStorage across remounts.
- Persists user toggling back to localStorage.
- Forces submenu open when navigating to a system route.
- Force-open does **not** overwrite a stored `true` (regression guard).

```
✓ src/components/app-sidebar.test.tsx (5 tests) 409ms

Test Files  1 passed (1)
     Tests  5 passed (5)
```

Full frontend suite (`npx vitest run`): **61/61 pass**.
`tsc -b --noEmit` and `npm run lint` clean for these files.

## Notes

Visual verification against the live dev stack was attempted but blocked
by an unrelated pre-existing issue on `main`: `pages[name] is not a
function` from Inertia's `import.meta.glob` resolver, repros on a clean
`main` checkout with no changes. Likely fallout from recent dependency
bumps. Filed separately if you want me to investigate — for this PR the
unit tests assert `aria-expanded` directly on the Collapsible trigger,
which is exactly what controls the visual state.
