### PR TITLE
test: fix flaky inlined-data-flush test via polling helper

### DIFF
--- a/backend/test/o11ylite/integration/scheduled_jobs/inlined_data_flush_test.clj
+++ b/backend/test/o11ylite/integration/scheduled_jobs/inlined_data_flush_test.clj
@@ -107,11 +107,13 @@
 
 (deftest flush-job-handles-empty-data-test
   (testing "Flush job succeeds with no inlined data"
-    ;; Wait for scheduler to trigger job with no data
-    (Thread/sleep 250)
-
-    ;; Job should still succeed
-    (let [job (get-flush-job-status)]
+    ;; Wait for the scheduler to trigger the job. Poll rather than
+    ;; sleeping a fixed budget — the tick + job future + DB write can
+    ;; exceed any fixed sleep under load, which is the historical flake.
+    (let [job (h/wait-until
+                #(let [j (get-flush-job-status)]
+                   (when (some? (:last_success_at j)) j))
+                {:label "inlined-data-flush success"})]
       (is (some? (:last_success_at job)) "Job should have succeeded")
       (is (nil? (:last_error job)) "Job should have no error"))))
 

--- a/backend/test/o11ylite/test_helpers.clj
+++ b/backend/test/o11ylite/test_helpers.clj
@@ -185,6 +185,39 @@
   (json/write-value-as-string data))
 
 ;; ---------------------------------------------------------
+;; Polling Helpers
+;;
+;; Prefer polling over fixed `Thread/sleep` waits in tests. A fixed
+;; sleep either wastes time on the happy path or flakes under load
+;; when an async step (scheduler tick + job future + DB write) runs
+;; slower than the budget. `wait-until` returns as soon as the
+;; predicate is truthy, and throws on timeout — failing fast with a
+;; useful error rather than asserting against stale state.
+
+(defn wait-until
+  "Poll `pred-fn` every `interval-ms` until it returns truthy, then
+   return that value. Throws `ex-info` if `timeout-ms` elapses first.
+
+   Defaults: timeout 5000 ms, interval 25 ms.
+
+   Usage:
+     (h/wait-until #(some? (:last_success_at (get-job-status))))
+     (h/wait-until pred {:timeout-ms 2000 :interval-ms 50 :label \"flush\"})"
+  ([pred-fn]
+   (wait-until pred-fn {}))
+  ([pred-fn {:keys [timeout-ms interval-ms label]
+             :or {timeout-ms 5000 interval-ms 25 label "condition"}}]
+   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+     (loop []
+       (let [v (pred-fn)]
+         (cond
+           v v
+           (>= (System/currentTimeMillis) deadline)
+           (throw (ex-info (str "wait-until timed out waiting for " label)
+                           {:timeout-ms timeout-ms :label label}))
+           :else (do (Thread/sleep interval-ms) (recur))))))))
+
+;; ---------------------------------------------------------
 ;; Re-exports: HTTP helpers
 
 (def url http/url)


### PR DESCRIPTION
## Problem

`o11ylite.integration.scheduled-jobs.inlined-data-flush-test/flush-job-handles-empty-data-test` (line 115) is flaky. It calls `Thread/sleep 250` then asserts `:last_success_at` is set on the `inlined-data-flush` job. The 250 ms budget covers:

1. scheduler tick (up to 100 ms with the test config),
2. acquiring the in-memory lock,
3. dispatching the job as a `future`,
4. running `ducklake/flush-inlined-data!`,
5. writing `last_success_at` to SQLite via `record-success!`.

Under CI load that chain occasionally takes longer than 250 ms, leaving `last_success_at` nil and the assertion fails.

## Fix

Replace the fixed sleep with a small `h/wait-until` polling helper in `test_helpers.clj`. It polls every 25 ms up to a 5 s timeout and returns the predicate value as soon as it's truthy — happy path is fast (single poll), slow CI gets the headroom it needs without flaking, and a real hang fails fast with a labelled timeout instead of asserting on stale state.

The helper lives in `o11ylite.test-helpers` so the three sibling scheduled-jobs tests (`parquet_compaction`, `telemetry_catalog_gc`, `daily_maintenance`) — which have the same `Thread/sleep 250` pattern — can adopt it in a follow-up.

## Verification

Ran the affected namespace 5× back-to-back, all green:

```
=== run 1 === 4 tests, 12 assertions, 0 failures.
=== run 2 === 4 tests, 12 assertions, 0 failures.
=== run 3 === 4 tests, 12 assertions, 0 failures.
=== run 4 === 4 tests, 12 assertions, 0 failures.
=== run 5 === 4 tests, 12 assertions, 0 failures.
```

Also reran `o11ylite.integration.components.scheduler-test` (other consumer of `test-helpers`) — 7 tests, 18 assertions, 0 failures.