### PR TITLE
chore: bump Java toolchain and runtime to 25 LTS

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-java openjdk-21
+java openjdk-25
 nodejs 24
 clojure 1.12.3.1577

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,7 +16,7 @@ OTLP Client  ──►  O11yLite  ──►  DuckDB / SQLite
 
 | Layer | Technology |
 |-------|-----------|
-| Backend | Clojure, Java 21 (virtual threads), Integrant |
+| Backend | Clojure, Java 25 (virtual threads), Integrant |
 | Frontend | React, TypeScript, Vite, Tailwind CSS, shadcn/ui |
 | Storage | DuckDB (analytics), SQLite (metadata) |
 | Ingestion | OTLP/gRPC, OTLP/HTTP (protobuf) |
@@ -243,7 +243,7 @@ docker run -d \
 
 The image includes:
 - **Caddy** - Reverse proxy serving frontend static assets and proxying to backend
-- **Backend** - Clojure uberjar running on Java 21 with virtual threads
+- **Backend** - Clojure uberjar running on Java 25 with virtual threads
 - **s6-overlay** - Process supervisor managing both services
 
 **Note:** The container is configured to exit on backend crash (rather than silently restarting), allowing container orchestrators (Docker, Kubernetes) to handle failures appropriately.

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN npm run build
 # Stage 2: Backend Build
 # =============================================================================
 # Use non-Alpine image because grpc-java plugin requires glibc
-FROM clojure:temurin-21-tools-deps AS backend-build
+FROM clojure:temurin-25-tools-deps AS backend-build
 
 # Application version baked into the uberjar (override at build time)
 ARG VERSION=dev
@@ -59,7 +59,7 @@ RUN clojure -J-Do11ylite.version=${VERSION} -T:build/task uberjar
 # Stage 3: Runtime Image
 # =============================================================================
 # Use Debian-based image for DuckDB glibc compatibility
-FROM eclipse-temurin:21-jre-noble AS runtime
+FROM eclipse-temurin:25-jre-noble AS runtime
 
 # s6-overlay version
 ARG S6_OVERLAY_VERSION=3.2.0.2


### PR DESCRIPTION
Bumps the entire Java toolchain — build *and* runtime — from JDK/JRE 21 to 25 (the next LTS, GA Sep 2025).

## Changes

- `.tool-versions`: `openjdk-21` → `openjdk-25`
- `Dockerfile` build stage: `clojure:temurin-21-tools-deps` → `clojure:temurin-25-tools-deps`
- `Dockerfile` runtime: `eclipse-temurin:21-jre-noble` → `eclipse-temurin:25-jre-noble`
- `DEVELOPMENT.md`: docs reference Java 25

## Why this instead of #135

#135 (Renovate) only bumps the runtime image, leaving the build stage on JDK 21. That means JDK 21 bytecode running on JRE 25 — supported, but uncoordinated. CI is red on #135 and we have no easy way to tell whether the failure is a real Java 25 incompatibility or a build/runtime mismatch artifact.

Moving build and runtime together is the cleaner upgrade and surfaces real issues (deps that break on JDK 25, agent compatibility, etc.) in one place. If CI is green here, we close #135. If it's red, we fix forward.

## What to watch in CI

Likely suspects if anything breaks (per [Java 24/25 release notes](https://openjdk.org/projects/jdk/25/)):

- Native-access warnings from DuckDB / gRPC-Netty (may need `--enable-native-access=ALL-UNNAMED`)
- `sun.misc.Unsafe` memory-access methods removed
- Security Manager permanently disabled (we don't use it, should be fine)
- OpenTelemetry javaagent version must support JDK 25

Supersedes #135.