### PR TITLE
fix(frontend): chart hover tooltip rendering under the legend

### DIFF
--- a/frontend/src/components/ui/chart.stacking.test.tsx
+++ b/frontend/src/components/ui/chart.stacking.test.tsx
@@ -1,0 +1,70 @@
+// Regression test for: hover tooltip rendering UNDERNEATH the legend on
+// recharts charts.
+//
+// Recharts mounts `.recharts-tooltip-wrapper` and `.recharts-legend-
+// wrapper` as absolute-positioned siblings inside `.recharts-wrapper`,
+// neither with a default z-index. Paint order then follows DOM order —
+// the legend is mounted after the tooltip, so it ends up on top and
+// covers the bottom of the tooltip popover when they collide.
+//
+// The supported fix is to pass `wrapperStyle={{ zIndex: ... }}` to the
+// Tooltip. We override `ChartTooltip` here to set a default zIndex, so
+// every chart in the codebase gets the right stacking automatically.
+//
+// We render a fixed-size `<LineChart>` directly (skipping the
+// ResponsiveContainer that ChartContainer normally wraps) because jsdom
+// can't size a ResponsiveContainer and the chart would refuse to render
+// its surface/tooltip wrapper. Reading `.style.zIndex` is sufficient —
+// Recharts writes `wrapperStyle` as inline CSS on the wrapper div
+// (see TooltipBoundingBox in recharts), so the value is directly
+// observable without computed-style support.
+import { render } from "@testing-library/react"
+import { describe, it, expect } from "vitest"
+import { Legend, Line, LineChart } from "recharts"
+
+import { ChartTooltip } from "./chart"
+
+describe("ChartTooltip recharts wrapper stacking", () => {
+  it("defaults to a z-index that paints above the legend", () => {
+    const { container } = render(
+      <LineChart width={400} height={200} data={[{ x: 0, a: 1 }]}>
+        <Line dataKey="a" />
+        <ChartTooltip defaultIndex={0} />
+        <Legend />
+      </LineChart>,
+    )
+
+    const tooltipWrapper = container.querySelector(".recharts-tooltip-wrapper")
+    const legendWrapper = container.querySelector(".recharts-legend-wrapper")
+
+    expect(tooltipWrapper).toBeTruthy()
+    expect(legendWrapper).toBeTruthy()
+
+    // Recharts writes `wrapperStyle` as inline CSS on the tooltip
+    // wrapper. Our ChartTooltip default seeds zIndex=10.
+    const tooltipZ = (tooltipWrapper as HTMLElement).style.zIndex
+    const legendZ = (legendWrapper as HTMLElement).style.zIndex
+
+    expect(Number(tooltipZ)).toBeGreaterThan(0)
+    // Legend stays at recharts' default — no z-index. If a future
+    // recharts version starts setting one, we still need to beat it.
+    if (legendZ !== "" && legendZ !== "auto") {
+      expect(Number(tooltipZ)).toBeGreaterThan(Number(legendZ))
+    }
+  })
+
+  it("lets callers override the z-index via wrapperStyle prop", () => {
+    // Sanity check that we merge, don't clobber, caller-supplied
+    // wrapperStyle. Callers reach for this when they need to e.g.
+    // raise the tooltip above a sticky page header.
+    const { container } = render(
+      <LineChart width={400} height={200} data={[{ x: 0, a: 1 }]}>
+        <Line dataKey="a" />
+        <ChartTooltip defaultIndex={0} wrapperStyle={{ zIndex: 99 }} />
+      </LineChart>,
+    )
+    const tooltipWrapper = container.querySelector(".recharts-tooltip-wrapper")
+    expect((tooltipWrapper as HTMLElement).style.zIndex).toBe("99")
+  })
+})
+

--- a/frontend/src/components/ui/chart.tsx
+++ b/frontend/src/components/ui/chart.tsx
@@ -107,7 +107,27 @@ ${colorConfig
   )
 }
 
-const ChartTooltip = RechartsPrimitive.Tooltip
+// Wrap Recharts' Tooltip so the tooltip wrapper always paints above the
+// chart's own legend (and any other absolutely-positioned chrome that
+// Recharts renders inside `.recharts-wrapper`). Both `.recharts-
+// tooltip-wrapper` and `.recharts-legend-wrapper` are absolute-
+// positioned siblings with no z-index of their own, so paint order
+// follows DOM order — and Recharts mounts the legend *after* the
+// tooltip, so without intervention the legend wins and obscures the
+// bottom of the hover popover. Recharts exposes `wrapperStyle` as the
+// supported API for tooltip wrapper styling; setting z-index here means
+// callers don't have to remember to.
+function ChartTooltip({
+  wrapperStyle,
+  ...props
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip>) {
+  return (
+    <RechartsPrimitive.Tooltip
+      wrapperStyle={{ zIndex: 10, ...wrapperStyle }}
+      {...props}
+    />
+  )
+}
 
 function ChartTooltipContent({
   active,


### PR DESCRIPTION
## Problem

On every time-series chart, the hover tooltip popover renders **underneath** the legend strip at the bottom of the chart. When the tooltip's natural placement extends near the chart's bottom edge, the legend covers the lower rows of the popover — making the highest-cardinality data (the rows that pushed the popover down in the first place) unreadable.

## Root cause

Recharts mounts `.recharts-tooltip-wrapper` and `.recharts-legend-wrapper` as absolute-positioned siblings under `.recharts-wrapper`, with **no `z-index`** on either. With identical stacking levels, paint order follows DOM order — the legend is mounted *after* the tooltip, so the legend wins.

This surfaced after the recharts v3 upgrade because v3 changed enough about layout/positioning to make the collision visible in normal use. Recharts v2 had the same gap but happened to position things so the bug rarely manifested.

## Fix

Recharts v3 exposes [`wrapperStyle`](https://recharts.org/en-US/api/Tooltip#wrapperStyle) on `<Tooltip>` as the supported API for styling the tooltip wrapper (`wrapperStyle` flows through to the underlying absolute-positioned div via `TooltipBoundingBox`). Override the local `ChartTooltip` re-export so every chart in the codebase gets `zIndex: 10` by default — merged with any caller-supplied `wrapperStyle`, so callers can still raise it further if they have a sticky page header or modal to clear:

```tsx
function ChartTooltip({ wrapperStyle, ...props }) {
  return (
    <RechartsPrimitive.Tooltip
      wrapperStyle={{ zIndex: 10, ...wrapperStyle }}
      {...props}
    />
  )
}
```

Considered alternatives:
- **Tailwind `[&_.recharts-tooltip-wrapper]:z-10` on `ChartContainer`**: works, but reaches under recharts' API surface. The dedicated prop is cleaner.
- **Patch shadcn upstream**: the upstream `chart.tsx` has the same gap. Keeping the override local for now; happy to send a PR upstream as a follow-up.

## Test

New `chart.stacking.test.tsx`:
- Renders a real `<LineChart>` with `<ChartTooltip defaultIndex={0}>` + `<Legend>` and asserts the live tooltip wrapper's inline `style.zIndex` is `> 0` and beats the legend's. Reading the inline style is reliable in jsdom because Recharts writes `wrapperStyle` as an inline `style` attribute on the wrapper (no Tailwind / computed-style pipeline involved).
- A second case asserts caller-supplied `wrapperStyle.zIndex` overrides our default — guarding the merge order.

Verified to fail (`expected 0 to be greater than 0`) when the override is removed and pass when restored.

## Evidence

Reproduced against the live dev stack: Explore → Metrics → `jvm.memory.used` grouped by `attr.jvm.memory.pool.name` (8 series → multi-row legend at narrow viewports). Before/after screenshots delivered in chat.

All 63 frontend tests pass; lint and `tsc -b --noEmit` clean.
