### PR TITLE
feat: reject queries that reference missing fields with 400

### DIFF
--- a/backend/src/o11ylite/alert_rule/eval.clj
+++ b/backend/src/o11ylite/alert_rule/eval.clj
@@ -127,7 +127,7 @@
 
         "metrics"
         (let [metrics-query (-inject-time-range query eval-win)]
-          (if-let [validation-error (metrics.query/validate sqlite metrics-query)]
+          (if-let [validation-error (metrics.query/validate sqlite duckdb metrics-query)]
             {:state nil :error (str "Validation error: " (:error validation-error))}
             ;; :single-bucket? collapses every metric to one row per
             ;; group_by combination over the full eval window so HAVING

--- a/backend/src/o11ylite/api/query.clj
+++ b/backend/src/o11ylite/api/query.clj
@@ -33,7 +33,7 @@
   [duckdb sqlite]
   (fn [request]
     (let [query (:body request)]
-      (if-let [error (metrics.query/validate sqlite query)]
+      (if-let [error (metrics.query/validate sqlite duckdb query)]
         (response/json 400 error)
         (response/json 200 (metrics.query/execute duckdb sqlite query))))))
 

--- a/backend/src/o11ylite/store/events/query.clj
+++ b/backend/src/o11ylite/store/events/query.clj
@@ -15,6 +15,7 @@
     [next.jdbc :as jdbc]
     [o11ylite.store.events.query-cursor :as query-cursor]
     [o11ylite.store.events.query-schema :as query-schema]
+    [o11ylite.store.events.query-validation :as query-validation]
     [o11ylite.store.query-util :as query-util]))
 
 ;; ---------------------------------------------------------
@@ -22,7 +23,7 @@
 
 (defn validate
   "Validate an events query request.
-   Performs schema validation, then type-aware filter validation.
+   Performs schema validation, then field-existence and type-aware filter validation.
 
    `fields` is the events-table field metadata map
    ({keyword -> {:type t}}).
@@ -30,7 +31,8 @@
    Returns nil if valid, or error map with :error key if invalid."
   [fields query]
   (or (query-schema/validate query-schema/events-query query)
-      (query-schema/validate-filter-ops-with-metadata fields query)))
+      (query-validation/validate-fields-exist fields query)
+      (query-validation/validate-filter-ops-with-metadata fields query)))
 
 ;; ---------------------------------------------------------
 ;; Column Name Handling (delegated to query-util)

--- a/backend/src/o11ylite/store/events/query_schema.clj
+++ b/backend/src/o11ylite/store/events/query_schema.clj
@@ -7,7 +7,6 @@
 
 (ns o11ylite.store.events.query-schema
   (:require
-    [clojure.string :as str]
     [malli.core :as m]
     [malli.error :as me]))
 
@@ -173,59 +172,6 @@
    For default timestamp sorting, f is \"timestamp\".
    Accepts nil (or null in JSON) for first page."
   [:maybe [:string {:min 1}]])
-
-;; ---------------------------------------------------------
-;; Type-Aware Filter Validation
-
-(def valid-ops-by-type
-  "Valid filter operators for each field type."
-  {:string    #{"=" "!=" "contains" "exists" "starts-with"}
-   :integer   #{"=" "!=" ">" "<" ">=" "<=" "exists"}
-   :float     #{"=" "!=" ">" "<" ">=" "<=" "exists"}
-   :boolean   #{"=" "!=" "exists"}
-   :instant   #{"=" "!=" ">" "<" ">=" "<=" "exists"}})
-
-(defn- -validate-filter-op-for-type
-  "Validate that an operator is valid for the given field type.
-   Returns nil if valid, error map if invalid."
-  [field-op field-type field-name]
-  (let [valid-ops (get valid-ops-by-type field-type)]
-    (if-not (contains? valid-ops field-op)
-      {:error (format "operator '%s' is not valid for %s field '%s'. Valid operators: %s"
-                      field-op field-type field-name (str/join ", " (sort valid-ops)))}
-      nil)))
-
-(defn- -validate-filter-expr-with-metadata
-  "Recursively validate filter expression operators against field types.
-   Returns nil if valid, error map if invalid.
-   Unknown fields are skipped (allows querying before data exists)."
-  [events-schema filter-expr]
-  (cond
-    ;; Compound AND
-    (:and filter-expr)
-    (some #(-validate-filter-expr-with-metadata events-schema %)
-          (:and filter-expr))
-
-    ;; Compound OR
-    (:or filter-expr)
-    (some #(-validate-filter-expr-with-metadata events-schema %)
-          (:or filter-expr))
-
-    ;; Simple filter
-    :else
-    (when-let [field-meta (get events-schema (keyword (:field filter-expr)))]
-      (-validate-filter-op-for-type (:op filter-expr)
-                                    (:type field-meta)
-                                    (:field filter-expr)))))
-
-(defn validate-filter-ops-with-metadata
-  "Validate all filter operators are valid for their field types.
-   Returns nil if valid, {:error ...} if invalid.
-   Unknown fields are skipped (allows querying before data exists).
-   Having uses ref-based numeric comparisons (no field-type check needed)."
-  [events-schema {:keys [filter]}]
-  (when filter
-    (-validate-filter-expr-with-metadata events-schema filter)))
 
 ;; ---------------------------------------------------------
 ;; Events Query Schema

--- a/backend/src/o11ylite/store/events/query_validation.clj
+++ b/backend/src/o11ylite/store/events/query_validation.clj
@@ -1,0 +1,144 @@
+;; ---------------------------------------------------------
+;; o11ylite.store.events.query-validation
+;;
+;; Metadata-aware validation for events queries.
+;; Validates filter operators against field types and rejects
+;; references to fields that don't exist in the events schema.
+;;
+;; Mirrors the events/metrics split: query-schema is pure malli +
+;; cross-field structural checks; query-validation needs runtime
+;; state (the events-table field metadata map).
+;; ---------------------------------------------------------
+
+(ns o11ylite.store.events.query-validation
+  (:require
+    [clojure.string :as str]))
+
+;; ---------------------------------------------------------
+;; Type-Aware Filter Validation
+
+(def valid-ops-by-type
+  "Valid filter operators for each field type."
+  {:string    #{"=" "!=" "contains" "exists" "starts-with"}
+   :integer   #{"=" "!=" ">" "<" ">=" "<=" "exists"}
+   :float     #{"=" "!=" ">" "<" ">=" "<=" "exists"}
+   :boolean   #{"=" "!=" "exists"}
+   :instant   #{"=" "!=" ">" "<" ">=" "<=" "exists"}})
+
+(defn- -validate-filter-op-for-type
+  "Validate that an operator is valid for the given field type.
+   Returns nil if valid, error map if invalid."
+  [field-op field-type field-name]
+  (let [valid-ops (get valid-ops-by-type field-type)]
+    (if-not (contains? valid-ops field-op)
+      {:error (format "operator '%s' is not valid for %s field '%s'. Valid operators: %s"
+                      field-op field-type field-name (str/join ", " (sort valid-ops)))}
+      nil)))
+
+(defn- -validate-filter-expr-with-metadata
+  "Recursively validate filter expression operators against field types.
+   Returns nil if valid, error map if invalid.
+   Unknown fields are skipped (allows querying before data exists)."
+  [events-schema filter-expr]
+  (cond
+    ;; Compound AND
+    (:and filter-expr)
+    (some #(-validate-filter-expr-with-metadata events-schema %)
+          (:and filter-expr))
+
+    ;; Compound OR
+    (:or filter-expr)
+    (some #(-validate-filter-expr-with-metadata events-schema %)
+          (:or filter-expr))
+
+    ;; Simple filter
+    :else
+    (when-let [field-meta (get events-schema (keyword (:field filter-expr)))]
+      (-validate-filter-op-for-type (:op filter-expr)
+                                    (:type field-meta)
+                                    (:field filter-expr)))))
+
+(defn validate-filter-ops-with-metadata
+  "Validate all filter operators are valid for their field types.
+   Returns nil if valid, {:error ...} if invalid.
+   Unknown fields are skipped (allows querying before data exists).
+   Having uses ref-based numeric comparisons (no field-type check needed)."
+  [events-schema {:keys [filter]}]
+  (when filter
+    (-validate-filter-expr-with-metadata events-schema filter)))
+
+;; ---------------------------------------------------------
+;; Field-Existence Validation
+;;
+;; A saved query (notebook, alert rule, shared URL) can outlive the fields
+;; it references — operator-deleted via /system/data-management, GC'd by
+;; the telemetry catalog, or simply typo'd. The same condition arises when
+;; a user types a field name that has never been observed.
+;;
+;; Either way, if such a field reaches the SQL builder it produces a
+;; DuckDB binder error (HTTP 500). We catch it here instead: a query that
+;; names an unknown field is rejected with a 400 explaining exactly which
+;; field doesn't exist, so the UI can render a clean error.
+
+(defn- -known-field?
+  "Returns true if `field-name` is a column we recognize in the events
+   schema cache. Built-in columns (timestamp, service, ...) and attribute
+   columns (attr.*) are all populated by the cache."
+  [events-schema field-name]
+  (contains? events-schema (keyword field-name)))
+
+(defn- -collect-filter-fields
+  "Walk a filter expression and return a sequence of every field name it
+   references."
+  [filter-expr]
+  (cond
+    (:and filter-expr) (mapcat -collect-filter-fields (:and filter-expr))
+    (:or filter-expr) (mapcat -collect-filter-fields (:or filter-expr))
+    :else [(:field filter-expr)]))
+
+(defn- -collect-referenced-fields
+  "Return the seq of field names a query references that need to resolve
+   to real columns at SQL time. Skips aggregation '*' (count(*)),
+   aggregation-id refs in having, and displayed_fields (UI-only)."
+  [{:keys [filter aggregations group_by visualization]}]
+  (let [agg-fields (->> aggregations
+                        (map :field)
+                        (remove #(= "*" %)))
+        sort-field (when-let [sort (and (= "table" (:type visualization))
+                                        (:sort visualization))]
+                     (:field sort))]
+    (cond-> (concat (when filter (-collect-filter-fields filter))
+                    agg-fields
+                    group_by)
+      sort-field (concat [sort-field]))))
+
+(defn validate-fields-exist
+  "Reject queries that reference fields not present in the events schema.
+   Returns nil if every referenced field exists, or {:error ...} naming
+   the first unknown field. Caller is the HTTP layer, which turns this
+   into a 400."
+  [events-schema query]
+  (when-let [unknown (->> (-collect-referenced-fields query)
+                          (remove #(-known-field? events-schema %))
+                          first)]
+    {:error (format "Field '%s' does not exist" unknown)}))
+
+;; ---------------------------------------------------------
+;; Rich Comment
+(comment
+
+  ;; Type-aware filter validation
+  (validate-filter-ops-with-metadata
+    {:service {:type :string}}
+    {:filter {:field "service" :op ">" :value "api"}})
+  ;; => {:error "operator '>' is not valid for :string field 'service'. ..."}
+
+  ;; Field-existence validation
+  (validate-fields-exist
+    {:service {:type :string}}
+    {:filter {:field "attr.foo" :op "=" :value "x"}
+     :visualization {:type "table"}})
+  ;; => {:error "Field 'attr.foo' does not exist"}
+
+  #_()) ; End of rich comment block
+;; ---------------------------------------------------------

--- a/backend/src/o11ylite/store/metrics/query.clj
+++ b/backend/src/o11ylite/store/metrics/query.clj
@@ -35,11 +35,11 @@
 
 (defn validate
   "Validate a metrics query request.
-   Performs schema validation, then metadata-aware validation.
+   Performs schema validation, then metadata- and schema-aware validation.
    Returns nil if valid, or {:error ...} if invalid."
-  [sqlite query]
+  [sqlite duckdb query]
   (or (query-schema/validate query-schema/metrics-query query)
-      (query-validation/validate-with-metadata sqlite query)))
+      (query-validation/validate-with-metadata sqlite duckdb query)))
 
 
 ;; ---------------------------------------------------------
@@ -188,7 +188,9 @@
    Looks up metric type from metadata to select appropriate aggregation columns.
    Each emitted series carries the metric's :unit so downstream consumers
    are self-contained.
-   Returns empty seq if referenced columns don't exist (graceful degradation)."
+   Returns empty seq if referenced columns don't exist (graceful degradation
+   for the narrow race between validate and execute — the common case is
+   caught earlier in `validate`)."
   [duckdb sqlite query metric bucket-ms single-bucket?]
   (let [{:keys [id name agg]} metric
         ;; Lookup metric metadata; default to :gauge for unknown metrics (graceful degradation)

--- a/backend/src/o11ylite/store/metrics/query_validation.clj
+++ b/backend/src/o11ylite/store/metrics/query_validation.clj
@@ -15,7 +15,8 @@
 (ns o11ylite.store.metrics.query-validation
   (:require
     [clojure.string :as str]
-    [o11ylite.store.metrics.metadata :as metadata]))
+    [o11ylite.store.metrics.metadata :as metadata]
+    [o11ylite.store.schema :as schema]))
 
 ;; ---------------------------------------------------------
 ;; Aggregation Rules
@@ -45,14 +46,59 @@
                         name id agg (clojure.core/name metric-type)
                         (str/join ", " (sort allowed)))}))))
 
+;; ---------------------------------------------------------
+;; Field-Existence Validation
+;;
+;; Unknown attribute columns in `group_by` or `filter` cause a DuckDB
+;; binder error at execution time (HTTP 500). We reject them here as
+;; 400 with a clear "Field 'X' does not exist" message so the frontend
+;; renders the same error UI it already uses for schema validation
+;; failures.
+;;
+;; Metric *names* are intentionally NOT validated: by historical design
+;; unknown metrics are skipped silently so dashboards/alerts can be
+;; authored before the first data point lands.
+
+(defn- -collect-filter-fields
+  [filter-expr]
+  (cond
+    (nil? filter-expr) []
+    (:and filter-expr) (mapcat -collect-filter-fields (:and filter-expr))
+    (:or filter-expr) (mapcat -collect-filter-fields (:or filter-expr))
+    :else [(:field filter-expr)]))
+
+(defn- -collect-referenced-fields
+  "Field names a metrics query expects to resolve to real columns:
+   global filter, per-metric filters, and group_by."
+  [{:keys [filter group_by metrics]}]
+  (concat (-collect-filter-fields filter)
+          (mapcat #(-collect-filter-fields (:filter %)) metrics)
+          group_by))
+
+(defn- -validate-fields-exist
+  "Reject queries that reference attribute fields not present in the
+   metrics table. Returns nil if all referenced fields exist, or
+   {:error ...} naming the first unknown one."
+  [duckdb query]
+  (let [referenced (-collect-referenced-fields query)]
+    (when (seq referenced)
+      (let [known (schema/fetch-metrics-field-names duckdb)]
+        (when-let [unknown (->> referenced
+                                (remove #(contains? known (keyword %)))
+                                first)]
+          {:error (format "Field '%s' does not exist" unknown)})))))
+
 (defn validate-with-metadata
-  "Validate query against metric metadata.
+  "Validate query against metric metadata and the metrics table schema.
    Returns nil if valid, {:error ...} if invalid.
-   
-   Unknown metrics are skipped (allows querying before data exists).
-   Only validates aggregation compatibility for known metrics."
-  [sqlite {:keys [metrics]}]
-  (first (keep #(-validate-metric-aggregation sqlite %) metrics)))
+
+   - Unknown metric *names* are skipped (allows querying before data exists).
+   - Unknown *fields* (group_by, filter) are rejected — they'd otherwise
+     produce a DuckDB binder error at execution time.
+   - Aggregation compatibility is checked for known metrics."
+  [sqlite duckdb {:keys [metrics] :as query}]
+  (or (first (keep #(-validate-metric-aggregation sqlite %) metrics))
+      (-validate-fields-exist duckdb query)))
 
 ;; ---------------------------------------------------------
 ;; Rich Comment

--- a/backend/test/o11ylite/integration/alert_rule_eval_test.clj
+++ b/backend/test/o11ylite/integration/alert_rule_eval_test.clj
@@ -298,11 +298,48 @@
               "Full-window sum 50 must fire; without single-bucket mode each sub-bucket sums to 10 and would not exceed threshold."))))))
 
 ;; ---------------------------------------------------------
-;; Rich Comment
-(comment
+;; Field disappears under a saved rule
 
-  (require '[clojure.test :refer [run-tests]])
-  (run-tests 'o11ylite.integration.alert-rule-eval-test)
+(deftest alert-rule-with-unknown-field-preserves-state-test
+  ;; A rule whose query references a field that no longer exists (operator
+  ;; deleted the field via /system/data-management, the catalog GC'd it,
+  ;; or it was only typo'd) used to crash the evaluator. We now surface
+  ;; this as a validation error from `validate`, which the eval loop
+  ;; treats as "unknown" — the rule's previous state is preserved instead
+  ;; of silently flipping to :ok, and the error is recorded so the rule
+  ;; shows up as broken in the rules list.
+  (testing "events rule: unknown field preserves prev state and records last_eval_error"
+    ;; Seed the rule into the firing state so we can prove the flip-to-ok
+    ;; regression doesn't happen.
+    (let [rule-id (create-alert-rule!
+                    {:name "Broken Field Events"
+                     :query {:filter {:field "service" :op "=" :value "broken-events"}
+                             :visualization {:type "table"}}
+                     :eval_window_ms 7200000})]
+      (h/ingest-sample-events! 3 {:service "broken-events"})
+      (alert-rule/run-evaluation-cycle! (duckdb) (sqlite) nil)
+      (is (= "firing" (get-rule-state rule-id))
+          "Sanity: rule is firing before the field disappears")
 
-  #_()) ; End of rich comment block
-;; ---------------------------------------------------------
+      ;; Simulate the field vanishing: rewrite the query to reference an
+      ;; attribute that was never observed by ingest. (Operator-deleted
+      ;; columns reach the same code path — what matters is the field is
+      ;; not in the events schema cache.)
+      (store/update! (sqlite) rule-id
+                     {:name "Broken Field Events"
+                      :description ""
+                      :enabled true
+                      :query_mode "events"
+                      :query {:filter {:field "attr.was_here_yesterday"
+                                       :op "=" :value "x"}
+                              :visualization {:type "table"}}
+                      :eval_window_ms 7200000
+                      :eval_interval_ms 0
+                      :alert_on "result"})
+      (alert-rule/run-evaluation-cycle! (duckdb) (sqlite) nil)
+
+      (let [rule (store/get-by-id (sqlite) rule-id)]
+        (is (= "firing" (:state rule))
+            "Prev state ('firing') must be preserved when the field disappears")
+        (is (re-find #"attr\.was_here_yesterday" (or (:last_eval_error rule) ""))
+            "last_eval_error must name the unknown field")))))

--- a/backend/test/o11ylite/integration/api/event_query_test.clj
+++ b/backend/test/o11ylite/integration/api/event_query_test.clj
@@ -31,6 +31,70 @@
       (is (h/json-response? response))
       (is (map? (get-in response [:body :error]))))))
 
+(deftest events-query-rejects-unknown-fields-test
+  ;; A query referencing a column that doesn't exist in the events table
+  ;; — operator-deleted, GC'd, or just typo'd — used to throw a DuckDB
+  ;; binder error and return 500. We now reject these at validation time
+  ;; with a 400 and a message naming the unknown field, so saved queries
+  ;; that outlive their schema fail cleanly instead of crashing the UI.
+  (let [now-ms (current-epoch-ms)
+        time-range {:start (- now-ms 3600000) :end (+ now-ms 60000)}]
+    (testing "unknown field in filter → 400 naming the field"
+      (let [response (h/post-json
+                       "/api/query/events"
+                       {:time_range time-range
+                        :filter {:field "attr.does_not_exist"
+                                 :op "=" :value "x"}
+                        :limit 10
+                        :visualization {:type "table"}})]
+        (is (= 400 (h/status response)))
+        (is (= "Field 'attr.does_not_exist' does not exist"
+               (get-in response [:body :error])))))
+
+    (testing "unknown field in group_by → 400"
+      (let [response (h/post-json
+                       "/api/query/events"
+                       {:time_range time-range
+                        :group_by ["attr.nope"]
+                        :aggregations [{:id "A" :field "*" :function "count"}]
+                        :visualization {:type "table"}})]
+        (is (= 400 (h/status response)))
+        (is (= "Field 'attr.nope' does not exist"
+               (get-in response [:body :error])))))
+
+    (testing "unknown field in aggregation → 400"
+      (let [response (h/post-json
+                       "/api/query/events"
+                       {:time_range time-range
+                        :aggregations [{:id "A" :field "attr.absent"
+                                        :function "avg"}]
+                        :visualization {:type "table"}})]
+        (is (= 400 (h/status response)))
+        (is (= "Field 'attr.absent' does not exist"
+               (get-in response [:body :error])))))
+
+    (testing "unknown field in table sort → 400"
+      (let [response (h/post-json
+                       "/api/query/events"
+                       {:time_range time-range
+                        :limit 10
+                        :visualization {:type "table"
+                                        :sort {:field "attr.ghost"
+                                               :order "desc"}}})]
+        (is (= 400 (h/status response)))
+        (is (= "Field 'attr.ghost' does not exist"
+               (get-in response [:body :error])))))
+
+    (testing "count(*) aggregation is not treated as a missing field"
+      ;; '*' is the wildcard for count(*) — must not be validated as a column.
+      (let [response (h/post-json
+                       "/api/query/events"
+                       {:time_range time-range
+                        :aggregations [{:id "A" :field "*"
+                                        :function "count"}]
+                        :visualization {:type "table"}})]
+        (is (= 200 (h/status response)))))))
+
 ;; ---------------------------------------------------------
 ;; Table Visualization
 
@@ -395,7 +459,7 @@
     (let [response (h/post-json "/api/query/events"
                                 {:time_range {:start 1702000000000
                                               :end 1702003600000}
-                                 :group_by ["duration_ms"]
+                                 :group_by ["service"]
                                  :visualization {:type "heatmap"}})]
       (is (= 200 (h/status response)))
       (is (h/json-response? response))

--- a/backend/test/o11ylite/integration/api/metric_query_test.clj
+++ b/backend/test/o11ylite/integration/api/metric_query_test.clj
@@ -74,6 +74,60 @@
       (is (string? (get-in response [:body :error])))
       (is (re-find #"not valid for sum" (get-in response [:body :error]))))))
 
+(deftest metrics-query-rejects-unknown-fields-test
+  ;; A metrics query that references an attribute column not present on
+  ;; the metrics table — e.g. a saved alert rule grouping by attr.host
+  ;; after the field was deleted — used to silently return empty results
+  ;; (the column-not-found exception was swallowed). It now fails fast
+  ;; with a 400 naming the unknown field, matching events behavior.
+  ;;
+  ;; Unknown *metric names* remain lenient (see -test below) so rules
+  ;; can still be authored before the first data point lands.
+  (h/ingest-sample-metrics! 1 {:name "cpu.utilization"
+                               :attr.host.name "server-1"})
+
+  (let [time-range {:start 1702000000000 :end 1702003600000}]
+    (testing "unknown attribute in group_by → 400"
+      (let [response (h/post-json
+                       "/api/query/metrics"
+                       {:time_range time-range
+                        :metrics [{:id "A" :name "cpu.utilization" :agg "avg"}]
+                        :group_by ["attr.no_such_attribute"]})]
+        (is (= 400 (h/status response)))
+        (is (= "Field 'attr.no_such_attribute' does not exist"
+               (get-in response [:body :error])))))
+
+    (testing "unknown attribute in global filter → 400"
+      (let [response (h/post-json
+                       "/api/query/metrics"
+                       {:time_range time-range
+                        :filter {:field "attr.absent" :op "=" :value "x"}
+                        :metrics [{:id "A" :name "cpu.utilization" :agg "avg"}]})]
+        (is (= 400 (h/status response)))
+        (is (= "Field 'attr.absent' does not exist"
+               (get-in response [:body :error])))))
+
+    (testing "unknown attribute in per-metric filter → 400"
+      (let [response (h/post-json
+                       "/api/query/metrics"
+                       {:time_range time-range
+                        :metrics [{:id "A" :name "cpu.utilization" :agg "avg"
+                                   :filter {:field "attr.ghost"
+                                            :op "=" :value "x"}}]})]
+        (is (= 400 (h/status response)))
+        (is (= "Field 'attr.ghost' does not exist"
+               (get-in response [:body :error])))))
+
+    (testing "unknown metric name is still allowed (intentional leniency)"
+      ;; Pre-existing design: queries against not-yet-emitted metrics
+      ;; succeed with empty results, so dashboards/alerts can be set up
+      ;; before data flows.
+      (let [response (h/post-json
+                       "/api/query/metrics"
+                       {:time_range time-range
+                        :metrics [{:id "A" :name "never.emitted" :agg "avg"}]})]
+        (is (= 200 (h/status response)))))))
+
 ;; ---------------------------------------------------------
 ;; Auto Bucket Selection
 

--- a/backend/test/o11ylite/store/events/query_schema_test.clj
+++ b/backend/test/o11ylite/store/events/query_schema_test.clj
@@ -317,115 +317,16 @@
 
 ;; ---------------------------------------------------------
 ;; Type-Aware Filter Validation
+;;
+;; (tests moved to o11ylite.store.events.query-validation-test)
 
 (def ^:private test-events-schema
-  "Mock event metadata for testing type-aware validation."
+  "Mock event metadata for testing. Used below by normalize-filter-test."
   {:service   {:type :string}
    :status    {:type :integer}
    :duration  {:type :float}
    :is_error  {:type :boolean}
    :timestamp {:type :instant}})
-
-(defn- type-valid?
-  "Check if filter operators are valid for field types."
-  [query]
-  (nil? (schema/validate-filter-ops-with-metadata test-events-schema query)))
-
-(defn- type-invalid?
-  "Check if filter operators are invalid for field types."
-  [query]
-  (some? (schema/validate-filter-ops-with-metadata test-events-schema query)))
-
-(deftest type-aware-filter-validation-test
-  (testing "string fields accept string operators"
-    (doseq [op ["=" "!=" "contains" "exists" "starts-with"]]
-      (is (type-valid? {:filter {:field "service" :op op :value "api"}})
-          (str "string field should accept operator: " op))))
-
-  (testing "string fields reject numeric operators"
-    (doseq [op [">" "<" ">=" "<="]]
-      (is (type-invalid? {:filter {:field "service" :op op :value "api"}})
-          (str "string field should reject operator: " op))))
-
-  (testing "integer fields accept numeric operators"
-    (doseq [op ["=" "!=" ">" "<" ">=" "<=" "exists"]]
-      (is (type-valid? {:filter {:field "status" :op op :value 500}})
-          (str "integer field should accept operator: " op))))
-
-  (testing "integer fields reject string operators"
-    (doseq [op ["contains" "starts-with"]]
-      (is (type-invalid? {:filter {:field "status" :op op :value 500}})
-          (str "integer field should reject operator: " op))))
-
-  (testing "float fields accept numeric operators"
-    (doseq [op ["=" "!=" ">" "<" ">=" "<=" "exists"]]
-      (is (type-valid? {:filter {:field "duration" :op op :value 100.5}})
-          (str "float field should accept operator: " op))))
-
-  (testing "float fields reject string operators"
-    (doseq [op ["contains" "starts-with"]]
-      (is (type-invalid? {:filter {:field "duration" :op op :value 100.5}})
-          (str "float field should reject operator: " op))))
-
-  (testing "boolean fields accept boolean operators"
-    (doseq [op ["=" "!=" "exists"]]
-      (is (type-valid? {:filter {:field "is_error" :op op :value true}})
-          (str "boolean field should accept operator: " op))))
-
-  (testing "boolean fields reject comparison and string operators"
-    (doseq [op [">" "<" ">=" "<=" "contains" "starts-with"]]
-      (is (type-invalid? {:filter {:field "is_error" :op op :value true}})
-          (str "boolean field should reject operator: " op))))
-
-  (testing "instant fields accept comparison operators"
-    (doseq [op ["=" "!=" ">" "<" ">=" "<=" "exists"]]
-      (is (type-valid? {:filter {:field "timestamp" :op op :value 1702000000000}})
-          (str "instant field should accept operator: " op))))
-
-  (testing "instant fields reject string operators"
-    (doseq [op ["contains" "starts-with"]]
-      (is (type-invalid? {:filter {:field "timestamp" :op op :value 1702000000000}})
-          (str "instant field should reject operator: " op))))
-
-  (testing "unknown fields are allowed (skipped validation)"
-    (is (type-valid? {:filter {:field "unknown_field" :op ">" :value 100}})
-        "unknown fields should be allowed to support querying before data exists"))
-
-  (testing "nested AND filters validate all clauses"
-    (is (type-valid? {:filter {:and [{:field "service" :op "=" :value "api"}
-                                     {:field "status" :op ">=" :value 500}]}})
-        "valid nested AND should pass")
-    (is (type-invalid? {:filter {:and [{:field "service" :op ">" :value "api"}
-                                       {:field "status" :op ">=" :value 500}]}})
-        "invalid op in nested AND should fail"))
-
-  (testing "nested OR filters validate all clauses"
-    (is (type-valid? {:filter {:or [{:field "status" :op "=" :value 404}
-                                    {:field "status" :op "=" :value 500}]}})
-        "valid nested OR should pass")
-    (is (type-invalid? {:filter {:or [{:field "service" :op ">" :value "api"}
-                                      {:field "status" :op "=" :value 500}]}})
-        "invalid op in nested OR should fail"))
-
-  (testing "deeply nested filters validate correctly"
-    (is (type-valid? {:filter {:and [{:field "service" :op "=" :value "api"}
-                                     {:or [{:field "status" :op ">=" :value 500}
-                                           {:field "is_error" :op "=" :value true}]}]}})
-        "valid deeply nested filter should pass")
-    (is (type-invalid? {:filter {:and [{:field "service" :op "=" :value "api"}
-                                       {:or [{:field "status" :op "contains" :value "500"}
-                                             {:field "is_error" :op "=" :value true}]}]}})
-        "invalid op in deeply nested filter should fail"))
-
-  (testing "error message includes field info"
-    (let [result (schema/validate-filter-ops-with-metadata
-                   test-events-schema
-                   {:filter {:field "service" :op ">" :value "api"}})]
-      (is (some? result) "should return error")
-      (is (string? (:error result)) "error should be a string")
-      (is (.contains (:error result) "service") "error should mention field name")
-      (is (.contains (:error result) ">") "error should mention invalid operator")
-      (is (.contains (:error result) ":string") "error should mention field type"))))
 
 ;; ---------------------------------------------------------
 ;; Sort Config Validation (ref-based sort)

--- a/backend/test/o11ylite/store/events/query_validation_test.clj
+++ b/backend/test/o11ylite/store/events/query_validation_test.clj
@@ -1,0 +1,122 @@
+;; ---------------------------------------------------------
+;; o11ylite.store.events.query-validation-test
+;;
+;; Unit tests for metadata-aware validation of events queries.
+;; ---------------------------------------------------------
+
+(ns o11ylite.store.events.query-validation-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [o11ylite.store.events.query-validation :as validation]))
+
+;; ---------------------------------------------------------
+;; Type-Aware Filter Validation
+
+(def ^:private test-events-schema
+  "Mock event metadata for testing type-aware validation."
+  {:service   {:type :string}
+   :status    {:type :integer}
+   :duration  {:type :float}
+   :is_error  {:type :boolean}
+   :timestamp {:type :instant}})
+
+(defn- type-valid?
+  "Check if filter operators are valid for field types."
+  [query]
+  (nil? (validation/validate-filter-ops-with-metadata test-events-schema query)))
+
+(defn- type-invalid?
+  "Check if filter operators are invalid for field types."
+  [query]
+  (some? (validation/validate-filter-ops-with-metadata test-events-schema query)))
+
+(deftest type-aware-filter-validation-test
+  (testing "string fields accept string operators"
+    (doseq [op ["=" "!=" "contains" "exists" "starts-with"]]
+      (is (type-valid? {:filter {:field "service" :op op :value "api"}})
+          (str "string field should accept operator: " op))))
+
+  (testing "string fields reject numeric operators"
+    (doseq [op [">" "<" ">=" "<="]]
+      (is (type-invalid? {:filter {:field "service" :op op :value "api"}})
+          (str "string field should reject operator: " op))))
+
+  (testing "integer fields accept numeric operators"
+    (doseq [op ["=" "!=" ">" "<" ">=" "<=" "exists"]]
+      (is (type-valid? {:filter {:field "status" :op op :value 500}})
+          (str "integer field should accept operator: " op))))
+
+  (testing "integer fields reject string operators"
+    (doseq [op ["contains" "starts-with"]]
+      (is (type-invalid? {:filter {:field "status" :op op :value 500}})
+          (str "integer field should reject operator: " op))))
+
+  (testing "float fields accept numeric operators"
+    (doseq [op ["=" "!=" ">" "<" ">=" "<=" "exists"]]
+      (is (type-valid? {:filter {:field "duration" :op op :value 100.5}})
+          (str "float field should accept operator: " op))))
+
+  (testing "float fields reject string operators"
+    (doseq [op ["contains" "starts-with"]]
+      (is (type-invalid? {:filter {:field "duration" :op op :value 100.5}})
+          (str "float field should reject operator: " op))))
+
+  (testing "boolean fields accept boolean operators"
+    (doseq [op ["=" "!=" "exists"]]
+      (is (type-valid? {:filter {:field "is_error" :op op :value true}})
+          (str "boolean field should accept operator: " op))))
+
+  (testing "boolean fields reject comparison and string operators"
+    (doseq [op [">" "<" ">=" "<=" "contains" "starts-with"]]
+      (is (type-invalid? {:filter {:field "is_error" :op op :value true}})
+          (str "boolean field should reject operator: " op))))
+
+  (testing "instant fields accept comparison operators"
+    (doseq [op ["=" "!=" ">" "<" ">=" "<=" "exists"]]
+      (is (type-valid? {:filter {:field "timestamp" :op op :value 1702000000000}})
+          (str "instant field should accept operator: " op))))
+
+  (testing "instant fields reject string operators"
+    (doseq [op ["contains" "starts-with"]]
+      (is (type-invalid? {:filter {:field "timestamp" :op op :value 1702000000000}})
+          (str "instant field should reject operator: " op))))
+
+  (testing "unknown fields are allowed (skipped validation)"
+    (is (type-valid? {:filter {:field "unknown_field" :op ">" :value 100}})
+        "unknown fields should be allowed to support querying before data exists"))
+
+  (testing "nested AND filters validate all clauses"
+    (is (type-valid? {:filter {:and [{:field "service" :op "=" :value "api"}
+                                     {:field "status" :op ">=" :value 500}]}})
+        "valid nested AND should pass")
+    (is (type-invalid? {:filter {:and [{:field "service" :op ">" :value "api"}
+                                       {:field "status" :op ">=" :value 500}]}})
+        "invalid op in nested AND should fail"))
+
+  (testing "nested OR filters validate all clauses"
+    (is (type-valid? {:filter {:or [{:field "status" :op "=" :value 404}
+                                    {:field "status" :op "=" :value 500}]}})
+        "valid nested OR should pass")
+    (is (type-invalid? {:filter {:or [{:field "service" :op ">" :value "api"}
+                                      {:field "status" :op "=" :value 500}]}})
+        "invalid op in nested OR should fail"))
+
+  (testing "deeply nested filters validate correctly"
+    (is (type-valid? {:filter {:and [{:field "service" :op "=" :value "api"}
+                                     {:or [{:field "status" :op ">=" :value 500}
+                                           {:field "is_error" :op "=" :value true}]}]}})
+        "valid deeply nested filter should pass")
+    (is (type-invalid? {:filter {:and [{:field "service" :op "=" :value "api"}
+                                       {:or [{:field "status" :op "contains" :value "500"}
+                                             {:field "is_error" :op "=" :value true}]}]}})
+        "invalid op in deeply nested filter should fail"))
+
+  (testing "error message includes field info"
+    (let [result (validation/validate-filter-ops-with-metadata
+                   test-events-schema
+                   {:filter {:field "service" :op ">" :value "api"}})]
+      (is (some? result) "should return error")
+      (is (string? (:error result)) "error should be a string")
+      (is (.contains (:error result) "service") "error should mention field name")
+      (is (.contains (:error result) ">") "error should mention invalid operator")
+      (is (.contains (:error result) ":string") "error should mention field type"))))

--- a/backend/test/o11ylite/store/metrics/query_validation_test.clj
+++ b/backend/test/o11ylite/store/metrics/query_validation_test.clj
@@ -24,10 +24,13 @@
 
 (defn- validate-with-mock
   "Validate query with mocked metadata.
-   metrics-map defines known metrics, query is the full query map."
+   metrics-map defines known metrics, query is the full query map.
+   `duckdb` is passed as nil — these tests only exercise the metadata
+   branch and never reference attribute fields, so the field-existence
+   check is short-circuited by the empty-references guard."
   [metrics-map query]
   (with-redefs [metadata/get-metric (mock-metadata metrics-map)]
-    (validation/validate-with-metadata nil query)))
+    (validation/validate-with-metadata nil nil query)))
 
 (defn- validate-single
   "Validate a single metric query with mocked metadata."

--- a/skills/o11ylite/docs/events-query.md
+++ b/skills/o11ylite/docs/events-query.md
@@ -316,4 +316,5 @@ Spans are ordered by timestamp. `meta.signal_type` is `"span"` or `"span_event"`
 |--------|------------------------|-----------------------------------------------|
 | 400    | `invalid_request`      | Schema validation failed (missing/invalid fields) |
 | 400    | `invalid_filter`       | Operator not valid for field type              |
+| 400    | `Field 'X' does not exist` | Query references a column not present in the events schema (deleted, GC'd, never observed, or typo'd) |
 | 401    | `unauthorized`         | Missing or invalid Bearer token                |

--- a/skills/o11ylite/docs/metrics-query.md
+++ b/skills/o11ylite/docs/metrics-query.md
@@ -264,4 +264,7 @@ The response contains three series per host: `A` (free bytes), `B`
 |--------|------------------------|----------------------------------------------------|
 | 400    | `invalid_request`      | Schema validation failed                           |
 | 400    | `invalid_aggregation`  | Aggregation not valid for metric type              |
+| 400    | `Field 'X' does not exist` | `group_by`, `filter`, or per-metric `filter` references an attribute column not on the metrics table |
 | 401    | `unauthorized`         | Missing or invalid Bearer token                    |
+
+> Unknown *metric names* are intentionally NOT rejected — queries for not-yet-emitted metrics succeed with empty results so dashboards and rules can be authored ahead of data.


### PR DESCRIPTION
## Problem

Saved queries (notebooks, alert rules, shared URLs) can outlive the fields they reference — operator-deleted via `/system/data-management`, GC'd by the telemetry catalog, or naming a field that was never observed. The same condition arises when a user just types a new field name into the query builder. Both used to throw a DuckDB Binder Error and return **HTTP 500**.

On the metrics side, queries referencing missing attribute columns were *silently* returning `[]` (the column-not-found exception was caught and swallowed). Charts appeared empty with no explanation.

## Approach

Treat an unknown field reference as a **validation error**. Same class as the existing "operator not valid for field type" or "heatmap requires exactly one group_by" checks — the query can't be evaluated, the user needs to fix it.

Both endpoints now respond:

```
HTTP 400
{ "error": "Field 'attr.foo' does not exist" }
```

## Backend

- **`store/events/query_validation.clj`** (new) — metadata-aware events validation: `validate-fields-exist` walks `filter` (recursive AND/OR), `aggregations[].field` (skipping `*`), `group_by`, and table-viz `sort.field`, checking each against the events-table schema; `validate-filter-ops-with-metadata` checks operator/type compatibility. `having` refs are aggregation IDs and `displayed_fields` is UI-only — both skipped.

- **`store/events/query_schema.clj`** — pure malli schemas + structural cross-field checks only. The metadata-aware fns moved out to `query_validation.clj` so the layout mirrors metrics (`query_schema` ↔ `query_validation`).

- **`store/events/query.clj`** — `validate` takes `fields` (resolved at the API boundary on each request — see #169) and now also calls `validate-fields-exist`.

- **`store/metrics/query_validation.clj`** — adds an attribute-existence check against `DESCRIBE o11ylite.metrics`. Unknown *metric names* are deliberately still lenient (pre-existing design: rules and dashboards can be authored before the first data point lands). Only unknown attribute columns in `group_by` / `filter` / per-metric `filter` are rejected.

- **`store/metrics/query.clj`** — `validate` takes `duckdb` too.

- **`alert_rule/eval.clj`** — *no logic changes*, just the new `duckdb` arg on the metrics `validate` call. The existing `validate` short-circuit produces `{state nil, error msg}` which the eval loop already treats as "preserve previous state + record last_eval_error". A rule pointing at a deleted field stays in its prior state and shows up as broken in the rules list rather than silently flipping to `:ok`.

### No more cache-sync workaround

The previous revision of this PR carried a `-wait-for-fields-in-cache!` polling helper in `test_helpers/event_ingest.clj` to bridge the async `:cache/events-schema` refresh and immediate validator reads. After rebasing onto #169 — which removes that cache entirely in favour of on-demand DuckLake DESCRIBE — the helper is unnecessary and has been dropped. Every consumer reads schema fresh; there's no window to bridge.

### Race window

There's a narrow gap between `validate` and `execute` where the catalog could change (operator deletes a field, GC drops a metric attribute). It's:

- Microseconds wide (validate and execute run in-process, back-to-back)
- Only triggered by rare operator actions (`/system/data-management`) or the catalog GC tick
- Easy for users to retry through

If it bites in practice we can add a binder-error catch later. Not worth the extra code right now.

## Frontend

No changes. `use-query-execution` already parses 4xx bodies as `{error}` and throws `Error(message)`. `telemetry-result.tsx` already routes `error instanceof Error` to `ResultsError` — the same path schema validation errors used. The user sees a clear "Field 'attr.foo' does not exist" in the chart area; the layout shell stays intact.

## Tests

Three new integration tests, all `with-system` (grouped `testing` blocks to amortize fixture cost per AGENTS.md):

- **`event_query_test.clj::events-query-rejects-unknown-fields-test`** — filter, group_by, aggregation.field, table sort.field each return 400 + named field; `count(*)` is not treated as a missing field.
- **`metric_query_test.clj::metrics-query-rejects-unknown-fields-test`** — group_by, global filter, per-metric filter each 400; unknown metric names still allowed (200).
- **`alert_rule_eval_test.clj::alert-rule-with-unknown-field-preserves-state-test`** — rule seeded into `firing`, query rewritten to reference an unknown field, eval cycle runs, prev state preserved + `last_eval_error` records the field name.

Unit tests for the moved fns live in the new `query_validation_test.clj`; the `query_schema_test.clj` keeps the pure-schema cases.

Side fix: `events-query-heatmap-test` was passing `:group_by ["duration_ms"]` (no such column — the real column is `span.duration_ms`). It only worked before because the heatmap implementation is a stub that ignores its input. Tightened to `"service"` so the test stays honest when heatmap gets implemented for real.

## Skill docs

`skills/o11ylite/docs/events-query.md` and `metrics-query.md` updated with the new 400 row in the Errors table. The metrics doc also notes the intentional metric-name leniency vs. attribute-name strictness.
