### PR TITLE
feat: per-group match alerts with enriched batched webhooks

### DIFF
--- a/backend/src/o11ylite/alert_rule/eval.clj
+++ b/backend/src/o11ylite/alert_rule/eval.clj
@@ -93,19 +93,29 @@
     (filterv #(= alert-target (:id %)) series)
     series))
 
+(defn- -latest-value
+  "The most recent datapoint value of a metrics series within the window.
+   Series data is ordered ascending by timestamp, so the last point is
+   newest. Returned as the value annotation source for match alerts."
+  [series]
+  (when-let [point (last (:data series))]
+    {:value (:value point)}))
+
 (defn- -metrics-presence
-  "Derive present groups from a metrics result. Each series with data
-   points is a present group, keyed by its labels' fingerprint.
+  "Derive present groups from a metrics result. A series is present iff
+   it contributes at least one datapoint within the window; a series with
+   zero datapoints is absent. Keyed by its labels' fingerprint.
    When alert-target is set, only that metric/formula's series count."
   [result alert-target group-fields]
   (let [series (-filter-by-target (get-in result [:data :series]) alert-target)
         with-data (filter #(pos? (count (:data %))) series)]
     (if (empty? group-fields)
-      (when (seq with-data) {fingerprint/empty-fingerprint {:labels {} :value nil}})
+      (when-let [s (first with-data)]
+        {fingerprint/empty-fingerprint {:labels {} :value (-latest-value s)}})
       (reduce (fn [acc s]
                 (let [labels (:labels s)
                       fp (fingerprint/fingerprint labels)]
-                  (assoc acc fp {:labels labels :value nil})))
+                  (assoc acc fp {:labels labels :value (-latest-value s)})))
               {}
               with-data))))
 
@@ -151,9 +161,9 @@
 (defn- -drive-instance!
   "Apply the state machine to one (rule, fingerprint). `stored` is the
    existing instance row or nil. `present` is {:labels :value} when the
-   group appeared this tick, else nil. Persists the result and returns
-   a notification descriptor {:status ... :instance ...} when the
-   transition notifies, else nil."
+   group appeared this tick, else nil. Persists the result and returns a
+   notification map {:status ... :labels ... :value ... :fingerprint ...
+   :started_at ... :resolved_at ...} when the transition notifies, else nil."
   [sqlite rule mode now fp stored present]
   (let [stored-state (if stored (keyword (:state stored)) :none)
         present? (some? present)
@@ -165,6 +175,7 @@
             started-at (if (= next-state :firing)
                          (or (:started_at stored) now)
                          (:started_at stored))
+            resolved-at (when (= next-state :resolved) now)
             last-value (if (:update-value? outcome)
                          (:value present)
                          (:last_value stored))
@@ -175,12 +186,18 @@
                  :first_seen first-seen
                  :last_seen now
                  :started_at started-at
-                 :resolved_at (when (= next-state :resolved) now)
+                 :resolved_at resolved-at
                  :last_value last-value}]
         (instance-store/upsert! sqlite row)
         (when (:delete? outcome)
           (instance-store/delete! sqlite (:id rule) fp))
-        nil))))
+        (when-let [notify (:notify outcome)]
+          {:status (name notify)
+           :labels labels
+           :value last-value
+           :fingerprint fp
+           :started_at started-at
+           :resolved_at resolved-at})))))
 
 (defn- -rollup-state
   "Worst-wins rule-level state from the rule's instances: :firing if any
@@ -193,53 +210,98 @@
 ;; ---------------------------------------------------------
 ;; Public API
 
+(def ^:private -max-instances-per-rule
+  "Cardinality cap. Once a rule holds this many instances, new
+   fingerprints are not minted; a single meta-alert fires on the rule."
+  500)
+
+(defn- -generator-url
+  "Deep link back to the rule in the UI. Absent a configured public base
+   URL, a relative path is the honest best we can do."
+  [rule-id]
+  (str "/alert-rules/" rule-id "/edit"))
+
+(defn- -meta-alert
+  "Synthetic firing notification on the rule itself when the cardinality
+   cap is hit. Labels carry the rule id and the cap so the receiver can
+   see the rule is shedding groups."
+  [rule]
+  {:status "firing"
+   :labels {:o11ylite_alert "cardinality_cap"}
+   :value {:max_instances -max-instances-per-rule}
+   :fingerprint "__meta_cardinality__"
+   :started_at (-now-ms)})
+
 (defn evaluate-rule!
   "Evaluate a single rule: run its query, drive the per-instance state
-   machine, and recompute the rule's rollup state.
+   machine, recompute the rule's rollup state, and collect the instance
+   transitions that should notify this tick.
 
-   Returns {:state :ok|:firing :error nil} on success, or
-   {:state nil :error string} on failure (caller preserves prev state,
-   no instance transitions happen)."
+   Returns {:state :ok|:firing :error nil :notifications [...]} on
+   success, or {:state nil :error string :notifications []} on failure
+   (caller preserves prev state, no instance transitions happen)."
   [duckdb sqlite {:keys [id alert_on query] :as rule}]
   (let [{:keys [present error]} (-eval-presence duckdb sqlite rule)]
     (if error
-      {:state nil :error error}
+      {:state nil :error error :notifications []}
       (let [mode (transitions/alert-on->mode alert_on)
             now (-now-ms)
             stored (instance-store/list-by-rule sqlite id)
             stored-by-fp (into {} (map (juxt :fingerprint identity)) stored)
+            stored-count (count stored-by-fp)
+            ;; At the cap, drive only fingerprints that already have a row
+            ;; (so existing instances still resolve); drop net-new ones.
+            capped? (>= stored-count -max-instances-per-rule)
+            present-fps (cond->> (keys present)
+                          capped? (filter #(contains? stored-by-fp %)))
             ;; A rule without group-by has exactly one group — the empty
             ;; fingerprint — and it is always tracked, even before any
             ;; eval has seen rows. This is what lets an ungrouped absence
             ;; rule fire the first time results come back empty.
             ungrouped? (empty? (:group_by query))
-            fps (cond-> (into (set (keys stored-by-fp)) (keys present))
-                  ungrouped? (conj fingerprint/empty-fingerprint))]
-        (doseq [fp fps]
-          (-drive-instance! sqlite rule mode now fp
-                            (get stored-by-fp fp)
-                            (get present fp)))
-        {:state (-rollup-state sqlite id) :error nil}))))
+            fps (cond-> (into (set (keys stored-by-fp)) present-fps)
+                  ungrouped? (conj fingerprint/empty-fingerprint))
+            notifications (into []
+                                (keep (fn [fp]
+                                        (-drive-instance! sqlite rule mode now fp
+                                                          (get stored-by-fp fp)
+                                                          (get present fp))))
+                                fps)
+            notifications (cond-> notifications
+                            (and capped? (seq (remove #(contains? stored-by-fp %) (keys present))))
+                            (conj (-meta-alert rule)))]
+        {:state (-rollup-state sqlite id)
+         :error nil
+         :notifications notifications}))))
 
 ;; ---------------------------------------------------------
 ;; Evaluation Cycle Orchestration
 
+(defn- -rule-ctx
+  "Rule-level context shared by every alert entry in a batch."
+  [{:keys [id name description]}]
+  {:id id
+   :name name
+   :description description
+   :rule-labels {}
+   :generator-url (-generator-url id)})
+
 (defn- -evaluate-and-notify!
-  "Evaluate a single rule and send notification if appropriate.
-   On evaluation failure (state is nil), preserves previous state."
+  "Evaluate a single rule, persist its rollup state, and send one batched
+   webhook for all instance transitions this tick. On evaluation failure
+   (state is nil), preserves previous state and sends nothing."
   [duckdb sqlite webhook-url rule]
   (let [{:keys [id state]} rule
         prev-state (keyword state)]
     (span/with-span! [::evaluate-rule {:o11ylite.alert_rule.id id
                                        :o11ylite.alert_rule.prev_state prev-state}]
-      (let [{:keys [state error]} (evaluate-rule! duckdb sqlite rule)
+      (let [{:keys [state error notifications]} (evaluate-rule! duckdb sqlite rule)
             new-state (or state prev-state)]
         (span/add-span-data! {:attributes {:o11ylite.alert_rule.new_state new-state
                                            :o11ylite.alert_rule.error error}})
         ;; Update rule rollup state (records last_eval_at and error even on failure)
         (store/update-eval-result! sqlite id new-state error prev-state)
-        ;; Send webhook notification
-        (notify/maybe-send-webhook! webhook-url rule new-state prev-state)))))
+        (notify/send-batch! webhook-url (-rule-ctx rule) notifications)))))
 
 (defn run-evaluation-cycle!
   "Evaluate all due alert rules and send notifications.

--- a/backend/src/o11ylite/alert_rule/notify.clj
+++ b/backend/src/o11ylite/alert_rule/notify.clj
@@ -2,18 +2,22 @@
 ;; o11ylite.alert-rule.notify
 ;;
 ;; Alertmanager-compatible webhook notification dispatch.
-;; Sends HTTP POST with v4 webhook payload format.
 ;;
-;; Notification policy:
-;;   - Sends on every eval while state is :firing
-;;     (Alertmanager expects repeated alerts to know they're still active)
-;;   - Sends once when transitioning from :firing to :ok (resolved)
-;;   - Silent when state is :ok and was already :ok
+;; One POST per rule per tick, carrying every instance transition from
+;; that tick batched into the Alertmanager `alerts` array. Each entry has
+;; its own status/labels/annotations/startsAt/endsAt/generatorURL, so a
+;; grouped rule reports per-group fire/resolve in a single request and an
+;; ungrouped rule degenerates to an array-of-one.
+;;
+;; Notifications are transition-driven: an instance that fires notifies
+;; once on fire and once on resolve. A still-firing instance does not
+;; re-notify each tick (repeat routing is out of scope).
 ;; ---------------------------------------------------------
 
 (ns o11ylite.alert-rule.notify
   (:require
     [babashka.http-client :as http]
+    [clojure.string :as str]
     [jsonista.core :as json]
     [o11ylite.util.telemetry :as telemetry]
     [steffan-westcott.clj-otel.api.trace.span :as span])
@@ -24,34 +28,54 @@
 ;; ---------------------------------------------------------
 ;; Private Helpers
 
+(def ^:private -zero-time
+  "Alertmanager's zero timestamp, used for endsAt while an alert is firing."
+  "0001-01-01T00:00:00Z")
+
 (defn- -epoch-ms->rfc3339
   "Convert epoch milliseconds to RFC3339 string."
   [epoch-ms]
   (when epoch-ms
-    (.format DateTimeFormatter/ISO_INSTANT
-             (Instant/ofEpochMilli epoch-ms))))
+    (.format DateTimeFormatter/ISO_INSTANT (Instant/ofEpochMilli epoch-ms))))
 
-(defn- -fingerprint
-  "Generate a stable fingerprint from a rule ID."
-  [rule-id]
-  (format "%016x" (hash rule-id)))
+(defn- -stringify-labels
+  "Coerce a label map's keys and values to strings for the labels object."
+  [labels]
+  (reduce-kv (fn [acc k v] (assoc acc (name k) (str v))) {} (or labels {})))
 
-(defn- -build-payload
-  "Build Alertmanager POST body."
-  [{:keys [id name description state_changed_at]} status]
-  (let [now-ms (System/currentTimeMillis)
-        starts-at (-epoch-ms->rfc3339 (or state_changed_at now-ms))
-        ends-at (when (= status "resolved") now-ms)
-        labels {"alertname" name
-                "source" "o11ylite"}
+(defn- -value->string
+  "Render an instance's last_value for the value annotation. A single
+   scalar renders bare; a map renders as comma-joined k=v pairs."
+  [value]
+  (cond
+    (nil? value) nil
+    (map? value) (->> value
+                      (map (fn [[k v]] (str (name k) "=" v)))
+                      sort
+                      (str/join ", "))
+    :else (str value)))
+
+(defn- -notification->alert
+  "Build one Alertmanager alert entry from an instance notification."
+  [{:keys [name description rule-labels generator-url]}
+   {:keys [status labels value fingerprint started_at resolved_at reason]}]
+  (let [merged-labels (merge {"alertname" name "source" "o11ylite"}
+                             (-stringify-labels rule-labels)
+                             (-stringify-labels labels))
+        value-str (-value->string value)
         annotations (cond-> {}
-                      description (assoc "description" description))]
-    [{:labels labels
-      :annotations annotations
-      :startsAt starts-at
-      :endsAt (if ends-at (-epoch-ms->rfc3339 ends-at) "0001-01-01T00:00:00Z")
-      :generatorURL ""
-      :fingerprint (-fingerprint id)}]))
+                      description (assoc "description" description)
+                      value-str (assoc "value" value-str)
+                      reason (assoc "reason" reason))]
+    {:status status
+     :labels merged-labels
+     :annotations annotations
+     :startsAt (or (-epoch-ms->rfc3339 started_at) -zero-time)
+     :endsAt (if (= status "resolved")
+               (or (-epoch-ms->rfc3339 resolved_at) (-epoch-ms->rfc3339 (System/currentTimeMillis)))
+               -zero-time)
+     :generatorURL (or generator-url "")
+     :fingerprint (str fingerprint)}))
 
 (defn- -send-http-post!
   "Send an HTTP POST with JSON body. Fire-and-forget with timeout."
@@ -68,39 +92,40 @@
 ;; ---------------------------------------------------------
 ;; Public API
 
-(defn maybe-send-webhook!
-  "Send Alertmanager-compatible webhook if appropriate.
-   Returns nil. Logs errors but does not throw."
-  [webhook-url rule new-state prev-state]
-  (when webhook-url
-    (let [should-send? (or (= new-state :firing)
-                           (and (= prev-state :firing) (= new-state :ok)))
-          status (case new-state
-                   :firing "firing"
-                   :ok "resolved"
-                   nil)]
-      (when (and should-send? status)
-        (span/with-span! [::send-webhook {:o11ylite.alert_rule.id (:id rule)
-                                          :o11ylite.alert_rule.webhook_status status
-                                          :url.full webhook-url}]
-          (try
-            (let [payload (-build-payload rule status)
-                  body (json/write-value-as-string payload)]
-              (-send-http-post! webhook-url body))
-            (catch Exception e
-              (telemetry/report-error! ::webhook-send-error e))))))))
+(defn build-payload
+  "Build the Alertmanager array body for a rule's batch of instance
+   notifications. `rule-ctx` carries rule-level fields (name, description,
+   rule-labels, generator-url); `notifications` is the per-instance batch."
+  [rule-ctx notifications]
+  (mapv #(-notification->alert rule-ctx %) notifications))
+
+(defn send-batch!
+  "POST a rule's batch of instance notifications as a single Alertmanager
+   array. No-op when there is no webhook URL or no notifications.
+   Logs errors but does not throw."
+  [webhook-url rule-ctx notifications]
+  (when (and webhook-url (seq notifications))
+    (span/with-span! [::send-webhook {:o11ylite.alert_rule.id (:id rule-ctx)
+                                      :o11ylite.alert_rule.alert_count (count notifications)
+                                      :url.full webhook-url}]
+      (try
+        (let [payload (build-payload rule-ctx notifications)
+              body (json/write-value-as-string payload)]
+          (-send-http-post! webhook-url body))
+        (catch Exception e
+          (telemetry/report-error! ::webhook-send-error e))))))
 
 ;; ---------------------------------------------------------
 ;; Rich Comment
 (comment
 
-  ;; Build a sample payload
-  (-build-payload
-    {:id "12345"
-     :name "High error rate"
-     :description "Error count exceeded threshold"
-     :state_changed_at 1702000000000}
-    "firing")
+  (build-payload
+    {:id "12345" :name "High error rate" :description "errors spiked"
+     :generator-url "https://o11y.example/alert-rules/12345/edit"}
+    [{:status "firing" :labels {:service "api"} :value {:error_rate 0.12}
+      :fingerprint "abc" :started_at 1702000000000}
+     {:status "resolved" :labels {:service "web"} :fingerprint "def"
+      :started_at 1702000000000 :resolved_at 1702000600000 :reason "dismissed"}])
 
   #_()) ; End of rich comment block
 ;; ---------------------------------------------------------

--- a/backend/test/o11ylite/alert_rule/notify_test.clj
+++ b/backend/test/o11ylite/alert_rule/notify_test.clj
@@ -1,0 +1,93 @@
+;; ---------------------------------------------------------
+;; o11ylite.alert-rule.notify-test
+;;
+;; Pure tests for the Alertmanager payload builder. The builder is a
+;; data -> data transform, so no system fixture is needed.
+;; ---------------------------------------------------------
+
+(ns o11ylite.alert-rule.notify-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [o11ylite.alert-rule.notify :as notify]))
+
+(def ^:private rule-ctx
+  {:id "rule-1"
+   :name "High error rate"
+   :description "errors spiked"
+   :rule-labels {}
+   :generator-url "/alert-rules/rule-1/edit"})
+
+(deftest array-shape-test
+  (testing "payload is an Alertmanager array, one entry per notification"
+    (let [payload (notify/build-payload
+                    rule-ctx
+                    [{:status "firing" :labels {:service "api"} :fingerprint "a" :started_at 1000}
+                     {:status "firing" :labels {:service "web"} :fingerprint "b" :started_at 1000}])]
+      (is (vector? payload))
+      (is (= 2 (count payload)))
+      (is (= #{"api" "web"} (set (map #(get-in % [:labels "service"]) payload)))))))
+
+(deftest ungrouped-degenerates-to-array-of-one-test
+  (testing "an ungrouped rule produces a single entry with empty fingerprint"
+    (let [payload (notify/build-payload
+                    rule-ctx
+                    [{:status "firing" :labels {} :fingerprint "" :started_at 1000}])]
+      (is (= 1 (count payload)))
+      (is (= "" (:fingerprint (first payload)))))))
+
+(deftest label-merge-test
+  (testing "group-by labels merge over the rule's base labels"
+    (let [alert (first (notify/build-payload
+                         rule-ctx
+                         [{:status "firing" :labels {:service "api" :region "us"}
+                           :fingerprint "a" :started_at 1000}]))]
+      (is (= "High error rate" (get-in alert [:labels "alertname"])))
+      (is (= "o11ylite" (get-in alert [:labels "source"])))
+      (is (= "api" (get-in alert [:labels "service"])))
+      (is (= "us" (get-in alert [:labels "region"]))))))
+
+(deftest value-annotation-test
+  (testing "scalar last_value renders bare in the value annotation"
+    (let [alert (first (notify/build-payload
+                         rule-ctx
+                         [{:status "firing" :labels {} :value "2/5 ready"
+                           :fingerprint "" :started_at 1000}]))]
+      (is (= "2/5 ready" (get-in alert [:annotations "value"])))))
+  (testing "map last_value renders as sorted k=v pairs"
+    (let [alert (first (notify/build-payload
+                         rule-ctx
+                         [{:status "firing" :labels {} :value {:error_rate 0.12 :count 5}
+                           :fingerprint "" :started_at 1000}]))]
+      (is (= "count=5, error_rate=0.12" (get-in alert [:annotations "value"])))))
+  (testing "absent value omits the annotation"
+    (let [alert (first (notify/build-payload
+                         rule-ctx
+                         [{:status "firing" :labels {} :fingerprint "" :started_at 1000}]))]
+      (is (not (contains? (:annotations alert) "value"))))))
+
+(deftest timestamps-test
+  (testing "firing entry has zero endsAt; resolved entry has a real endsAt"
+    (let [[firing resolved]
+          (notify/build-payload
+            rule-ctx
+            [{:status "firing" :labels {} :fingerprint "" :started_at 1700000000000}
+             {:status "resolved" :labels {} :fingerprint ""
+              :started_at 1700000000000 :resolved_at 1700000600000}])]
+      (is (= "0001-01-01T00:00:00Z" (:endsAt firing)))
+      (is (re-matches #"20\d{2}-.*Z" (:startsAt firing)))
+      (is (re-matches #"20\d{2}-.*Z" (:endsAt resolved))))))
+
+(deftest dismissal-reason-test
+  (testing "reason annotation rides along on a resolved entry"
+    (let [alert (first (notify/build-payload
+                         rule-ctx
+                         [{:status "resolved" :labels {:service "api"} :fingerprint "a"
+                           :started_at 1000 :resolved_at 2000 :reason "dismissed"}]))]
+      (is (= "dismissed" (get-in alert [:annotations "reason"]))))))
+
+(deftest generator-url-test
+  (testing "generatorURL is carried from the rule context"
+    (let [alert (first (notify/build-payload
+                         rule-ctx
+                         [{:status "firing" :labels {} :fingerprint "" :started_at 1000}]))]
+      (is (= "/alert-rules/rule-1/edit" (:generatorURL alert))))))

--- a/backend/test/o11ylite/integration/alert_match_group_test.clj
+++ b/backend/test/o11ylite/integration/alert_match_group_test.clj
@@ -1,0 +1,105 @@
+;; ---------------------------------------------------------
+;; o11ylite.integration.alert-match-group-test
+;;
+;; Step 2: per-group match semantics. A grouped match rule must track
+;; independent fire/resolve state per group, surface group labels and
+;; breaching values, and batch all of a tick's transitions. We assert on
+;; the notification batch returned by evaluate-rule! (the exact payload
+;; the webhook sends) plus the persisted instances.
+;;
+;; Each test gets a fresh system, so the only events in the store are the
+;; ones the test ingests. The rule groups by service with no filter; one
+;; instance is therefore minted per ingested service.
+;; ---------------------------------------------------------
+
+(ns o11ylite.integration.alert-match-group-test
+  (:require
+    [clojure.test :refer [deftest is testing use-fixtures]]
+    [o11ylite.alert-rule.eval :as alert-eval]
+    [o11ylite.alert-rule.instance-store :as instance-store]
+    [o11ylite.alert-rule.store :as store]
+    [o11ylite.test-helpers :as h])
+  (:import
+    [com.github.f4b6a3.uuid UuidCreator]))
+
+(use-fixtures :each h/with-system)
+
+(defn- sqlite
+  []
+  (:db/sqlite h/*system*))
+(defn- duckdb
+  []
+  (:db/duckdb-reader h/*system*))
+
+(defn- create-rule!
+  [overrides]
+  (let [id (str (UuidCreator/getTimeOrderedEpoch))
+        rule (merge {:name "Grouped Match"
+                     :description "t"
+                     :query_mode "events"
+                     :query {:group_by ["service"]
+                             :visualization {:type "table"}}
+                     :eval_window_ms 7200000
+                     :eval_interval_ms 0}
+                    overrides)]
+    (store/create! (sqlite) id rule)
+    id))
+
+(defn- eval-rule
+  [rule-id]
+  (alert-eval/evaluate-rule! (duckdb) (sqlite) (store/get-by-id (sqlite) rule-id)))
+
+(defn- instances
+  [rule-id]
+  (instance-store/list-by-rule (sqlite) rule-id))
+
+(defn- wait-for-events!
+  [n]
+  (h/wait-until
+    #(let [r (alert-eval/evaluate-rule! (duckdb) (sqlite)
+                                        {:query_mode "events" :alert_on "result"
+                                         :eval_window_ms 7200000
+                                         :query {:group_by ["service"] :visualization {:type "table"}}
+                                         :id "probe"})]
+       (when (>= (count (:notifications r)) n) r))
+    {:label "events visible"}))
+
+(deftest grouped-match-fires-per-group-test
+  (testing "a grouped match rule mints one firing instance per present group"
+    (h/ingest-sample-events! 3 {:service "svc-a"})
+    (h/ingest-sample-events! 2 {:service "svc-b"})
+    (wait-for-events! 2)
+    (let [rule-id (create-rule! {})
+          result (eval-rule rule-id)
+          inst (instances rule-id)
+          firing-services (set (map #(get-in % [:labels :service]) inst))]
+      (testing "one instance per present group"
+        (is (= 2 (count inst)))
+        (is (= #{"svc-a" "svc-b"} firing-services))
+        (is (every? #(= "firing" (:state %)) inst)))
+
+      (testing "every instance has a distinct fingerprint"
+        (is (= 2 (count (set (map :fingerprint inst))))))
+
+      (testing "the batch has one firing entry per group with service label"
+        (let [notifs (:notifications result)]
+          (is (= 2 (count notifs)))
+          (is (every? #(= "firing" (:status %)) notifs))
+          (is (= #{"svc-a" "svc-b"}
+                 (set (map #(get-in % [:labels :service]) notifs))))))
+
+      (testing "rule rollup is firing"
+        (is (= :firing (:state result)))))))
+
+(deftest grouped-match-no-renotify-while-firing-test
+  (testing "a continuously-firing group does not re-notify each tick"
+    (h/ingest-sample-events! 2 {:service "svc-x"})
+    (wait-for-events! 1)
+    (let [rule-id (create-rule! {})]
+      (let [r1 (eval-rule rule-id)]
+        (is (= 1 (count (instances rule-id))))
+        (is (= 1 (count (:notifications r1)))))
+      (let [r2 (eval-rule rule-id)]
+        (is (empty? (:notifications r2))
+            "still-firing must be silent")
+        (is (= 1 (count (instances rule-id))))))))


### PR DESCRIPTION
## Step 2 of 4: per-group match alerts + enriched webhooks

**Stacked on #190.** Base is `ming/alert-instances-foundation`; review only
this diff. GitHub will retarget to `main` once #190 merges.

Activates per-group semantics for **match (`result`) rules** and enriches
the Alertmanager payload. Ungrouped rules behave exactly as before via the
empty fingerprint.

### Webhook payload — now genuinely multi-instance

- One POST per rule per tick, batching every instance transition into the
  Alertmanager `alerts` array.
- Group-by columns → `labels` (merged over `alertname`/`source`).
- Breaching values → `value` annotation (scalar bare; map as sorted `k=v`).
- `generatorURL` → deep link to the rule. **Open sub-decision:** the plan
  wants a query deep-link with the window pre-filled, but the UI's query
  URL is a msgpack-encoded `?q=` blob and there's no public base-URL config
  in the app today. I shipped a relative `/alert-rules/:id/edit` link
  rather than build a server-side msgpack encoder + base-URL setting in
  this PR. Happy to do the full deep-link as a follow-up (needs a
  `public-base-url` config knob) — flag if you want it in-scope here.
- Transition-driven: fire once on fire, once on resolve; a
  continuously-firing instance is silent (no per-tick re-notify).

### Metrics presence (per the model you confirmed)

- A series is **present iff ≥1 datapoint in the window**; zero-datapoint
  series are absent.
- `alert_target` stays a pre-filter — only the targeted metric/formula's
  series mint instances. A fully-aggregated single series with empty
  labels degenerates to the empty fingerprint (consistent with ungrouped
  event rules).
- Fingerprint = the same canonicalization fn over the series `:labels`.
- `value` annotation = latest datapoint of the targeted series.

### Cardinality cap

Once a rule holds 500 instances, new fingerprints stop minting (existing
ones still resolve) and a single meta-alert fires on the rule — never a
silent drop.

### Tests

- `notify-test` (pure): array shape, label merge, value rendering
  (scalar/map), firing-vs-resolved timestamps, dismissal `reason`,
  `generatorURL`.
- `alert-match-group-test` (integration): grouped match mints one firing
  instance per group, emits one batched per-group entry, and stays silent
  while continuously firing.
- Full alert suite (eval/instance/CRUD/schema) green: 45 tests, 204
  assertions, 0 failures.

### Stack

1. #190 — foundation
2. **#(this)** — match per-group + enrichment + cap
3. absence per-group + tracked-groups UI + dismissal
4. docs

🤖 Generated with [Hermes](https://hermes-agent.nousresearch.com)


