### PR TITLE
feat: per-group absence alerts + tracked-group dismissal

### DIFF
--- a/backend/src/o11ylite/alert_rule.clj
+++ b/backend/src/o11ylite/alert_rule.clj
@@ -13,6 +13,7 @@
 (ns o11ylite.alert-rule
   (:require
     [o11ylite.alert-rule.eval :as eval]
+    [o11ylite.alert-rule.instance-store :as instance-store]
     [o11ylite.alert-rule.store :as store]))
 
 ;; ---------------------------------------------------------
@@ -23,6 +24,12 @@
 (def delete! store/delete!)
 (def get-by-id store/get-by-id)
 (def list-all store/list-all)
+
+;; ---------------------------------------------------------
+;; Re-exports from instance-store
+
+(def list-instances instance-store/list-by-rule)
+(def dismiss-instances! instance-store/delete-fingerprints!)
 
 ;; ---------------------------------------------------------
 ;; Re-exports from eval

--- a/backend/src/o11ylite/routes/alert_rules.clj
+++ b/backend/src/o11ylite/routes/alert_rules.clj
@@ -58,7 +58,8 @@
                        :errors (get-in request [:flash :errors] {})})))
 
 (defn- -make-edit-handler
-  "GET /alert-rules/:id/edit - Render edit form."
+  "GET /alert-rules/:id/edit - Render edit form. Includes the rule's
+   tracked alert instances so the form can surface and dismiss them."
   [{:keys [sqlite]}]
   (fn [request]
     (let [id (get-in request [:path-params :id])
@@ -66,6 +67,7 @@
       (if rule
         (response/inertia "AlertRuleEdit"
                           {:alert_rule rule
+                           :instances (alert-rule/list-instances sqlite id)
                            :errors (get-in request [:flash :errors] {})})
         (rr/not-found "Alert rule not found")))))
 
@@ -102,6 +104,18 @@
       (alert-rule/delete! sqlite id)
       (rr/redirect "/alert-rules" :see-other))))
 
+(defn- -make-dismiss-instances-handler
+  "POST /alert-rules/:id/instances/dismiss - Dismiss tracked instances by
+   fingerprint. Deletes the rows; a dismissed group re-tracks naturally on
+   a later eval (an ungrouped rule re-fires on the next empty eval, a
+   grouped rule re-tracks the next time the group is seen present)."
+  [{:keys [sqlite]}]
+  (fn [request]
+    (let [id (get-in request [:path-params :id])
+          fingerprints (get-in request [:body :fingerprints])]
+      (alert-rule/dismiss-instances! sqlite id fingerprints)
+      (rr/redirect (str "/alert-rules/" id "/edit") :see-other))))
+
 ;; ---------------------------------------------------------
 ;; Routes
 
@@ -115,4 +129,5 @@
    ["/:id"
     ["" {:put {:handler (-make-update-handler opts)}
          :delete {:handler (-make-delete-handler opts)}}]
-    ["/edit" {:get {:handler (-make-edit-handler opts)}}]]])
+    ["/edit" {:get {:handler (-make-edit-handler opts)}}]
+    ["/instances/dismiss" {:post {:handler (-make-dismiss-instances-handler opts)}}]]])

--- a/backend/test/o11ylite/integration/alert_absence_group_test.clj
+++ b/backend/test/o11ylite/integration/alert_absence_group_test.clj
@@ -1,0 +1,152 @@
+;; ---------------------------------------------------------
+;; o11ylite.integration.alert-absence-group-test
+;;
+;; Step 3: per-group absence semantics. A grouped absence rule tracks
+;; each group it has seen present (as :ok); when a tracked group later
+;; disappears from results, that group fires independently. Unlike match
+;; rules, a resolved absence group is retained (not deleted) — it stays a
+;; tracked group so it can fire again. This rides on the same generic
+;; eval loop as match: the only difference is the transition table.
+;;
+;; Each test gets a fresh system, so the only events in the store are the
+;; ones the test ingests.
+;; ---------------------------------------------------------
+
+(ns o11ylite.integration.alert-absence-group-test
+  (:require
+    [clojure.test :refer [deftest is testing use-fixtures]]
+    [o11ylite.alert-rule.eval :as alert-eval]
+    [o11ylite.alert-rule.instance-store :as instance-store]
+    [o11ylite.alert-rule.store :as store]
+    [o11ylite.test-helpers :as h])
+  (:import
+    [com.github.f4b6a3.uuid UuidCreator]))
+
+(use-fixtures :each h/with-system)
+
+(defn- sqlite
+  []
+  (:db/sqlite h/*system*))
+(defn- duckdb
+  []
+  (:db/duckdb-reader h/*system*))
+
+(defn- create-rule!
+  [overrides]
+  (let [id (str (UuidCreator/getTimeOrderedEpoch))
+        rule (merge {:name "Grouped Absence"
+                     :description "t"
+                     :query_mode "events"
+                     :alert_on "no_result"
+                     :query {:group_by ["service"]
+                             :visualization {:type "table"}}
+                     :eval_window_ms 7200000
+                     :eval_interval_ms 0}
+                    overrides)]
+    (store/create! (sqlite) id rule)
+    id))
+
+(defn- eval-rule
+  [rule-id]
+  (alert-eval/evaluate-rule! (duckdb) (sqlite) (store/get-by-id (sqlite) rule-id)))
+
+(defn- instances
+  [rule-id]
+  (instance-store/list-by-rule (sqlite) rule-id))
+
+(defn- instance-by-service
+  [rule-id svc]
+  (->> (instances rule-id)
+       (filter #(= svc (get-in % [:labels :service])))
+       first))
+
+(defn- wait-for-events!
+  [n]
+  (h/wait-until
+    #(let [r (alert-eval/evaluate-rule! (duckdb) (sqlite)
+                                        {:query_mode "events" :alert_on "result"
+                                         :eval_window_ms 7200000
+                                         :query {:group_by ["service"] :visualization {:type "table"}}
+                                         :id "probe"})]
+       (when (>= (count (:notifications r)) n) r))
+    {:label "events visible"}))
+
+(deftest grouped-absence-tracks-then-fires-per-group-test
+  (testing "a grouped absence rule tracks present groups, then fires per group on disappearance"
+    (h/ingest-sample-events! 2 {:service "svc-a"})
+    (h/ingest-sample-events! 2 {:service "svc-b"})
+    (wait-for-events! 2)
+    ;; Window the rule to the two seeded services so both are present on
+    ;; the first eval and become tracked :ok groups.
+    (let [rule-id (create-rule! {:query {:group_by ["service"]
+                                         :filter {:or [{:field "service" :op "=" :value "svc-a"}
+                                                       {:field "service" :op "=" :value "svc-b"}]}
+                                         :visualization {:type "table"}}})]
+      (testing "first eval: both present groups tracked as ok, no notifications"
+        (let [result (eval-rule rule-id)
+              inst (instances rule-id)]
+          (is (= 2 (count inst)))
+          (is (= #{"svc-a" "svc-b"} (set (map #(get-in % [:labels :service]) inst))))
+          (is (every? #(= "ok" (:state %)) inst))
+          (is (empty? (:notifications result)))
+          (is (= :ok (:state result)))))
+
+      ;; Narrow the rule so svc-b is no longer in results, svc-a still is.
+      ;; alert_on unchanged, so tracked instances are retained.
+      (store/update! (sqlite) rule-id
+                     {:name "Grouped Absence" :description "t" :enabled true
+                      :query_mode "events" :alert_on "no_result"
+                      :query {:group_by ["service"]
+                              :filter {:field "service" :op "=" :value "svc-a"}
+                              :visualization {:type "table"}}
+                      :eval_window_ms 7200000 :eval_interval_ms 0})
+
+      (testing "svc-b disappears -> only svc-b fires, svc-a stays ok"
+        (let [result (eval-rule rule-id)]
+          (is (= "firing" (:state (instance-by-service rule-id "svc-b"))))
+          (is (= "ok" (:state (instance-by-service rule-id "svc-a"))))
+          (testing "exactly one firing notification, for svc-b"
+            (let [notifs (:notifications result)]
+              (is (= 1 (count notifs)))
+              (is (= "firing" (:status (first notifs))))
+              (is (= "svc-b" (get-in (first notifs) [:labels :service])))))
+          (is (= :firing (:state result)) "rollup is firing while any group fires")))
+
+      (testing "resolved/absence groups are retained, not deleted"
+        (is (= 2 (count (instances rule-id)))
+            "both groups still tracked after one fires")))))
+
+(deftest grouped-absence-resolves-without-delete-test
+  (testing "a firing absence group resolves back to ok (retained) when it reappears"
+    (h/ingest-sample-events! 2 {:service "svc-x"})
+    (wait-for-events! 1)
+    (let [rule-id (create-rule! {:query {:group_by ["service"]
+                                         :filter {:field "service" :op "=" :value "svc-x"}
+                                         :visualization {:type "table"}}})]
+      ;; Track svc-x as ok.
+      (eval-rule rule-id)
+      (is (= "ok" (:state (instance-by-service rule-id "svc-x"))))
+      ;; Make it disappear -> fire.
+      (store/update! (sqlite) rule-id
+                     {:name "Grouped Absence" :description "t" :enabled true
+                      :query_mode "events" :alert_on "no_result"
+                      :query {:group_by ["service"]
+                              :filter {:field "service" :op "=" :value "NONE"}
+                              :visualization {:type "table"}}
+                      :eval_window_ms 7200000 :eval_interval_ms 0})
+      (let [r (eval-rule rule-id)]
+        (is (= "firing" (:state (instance-by-service rule-id "svc-x"))))
+        (is (= 1 (count (:notifications r)))))
+      ;; Bring it back -> resolve to ok, retained, resolve notification.
+      (store/update! (sqlite) rule-id
+                     {:name "Grouped Absence" :description "t" :enabled true
+                      :query_mode "events" :alert_on "no_result"
+                      :query {:group_by ["service"]
+                              :filter {:field "service" :op "=" :value "svc-x"}
+                              :visualization {:type "table"}}
+                      :eval_window_ms 7200000 :eval_interval_ms 0})
+      (let [r (eval-rule rule-id)]
+        (is (= "ok" (:state (instance-by-service rule-id "svc-x"))))
+        (is (= 1 (count (instances rule-id))) "retained, not deleted")
+        (is (= 1 (count (:notifications r))))
+        (is (= "resolved" (:status (first (:notifications r)))))))))

--- a/backend/test/o11ylite/integration/routes/alert_rules_test.clj
+++ b/backend/test/o11ylite/integration/routes/alert_rules_test.clj
@@ -9,9 +9,14 @@
   (:require
     [clojure.string :as str]
     [clojure.test :refer [deftest is testing use-fixtures]]
+    [o11ylite.alert-rule.instance-store :as instance-store]
     [o11ylite.test-helpers :as h]))
 
 (use-fixtures :each h/with-system)
+
+(defn- sqlite
+  []
+  (:db/sqlite h/*system*))
 
 ;; ---------------------------------------------------------
 ;; Helpers
@@ -197,3 +202,47 @@
         (is (= 303 (h/status response)))
         (is (= "/alert-rules" (h/header response "location")))
         (is (empty? (-list-rules)))))))
+
+;; ---------------------------------------------------------
+;; Tracked-group dismissal
+
+(defn- -edit-props
+  [rule-id]
+  (get-in (h/body (h/inertia-json-request (str "/alert-rules/" rule-id "/edit")))
+          [:props]))
+
+(deftest edit-includes-instances-test
+  (testing "Edit page props include the rule's tracked instances"
+    (let [session (h/csrf-session)]
+      (-create-rule! session)
+      (let [rule-id (:id (first (-list-rules)))
+            props (-edit-props rule-id)]
+        ;; No instances tracked yet for a freshly created rule.
+        (is (vector? (:instances props))
+            "instances prop should always be present as a vector")
+        (is (empty? (:instances props)))))))
+
+(deftest dismiss-instances-removes-tracked-groups-test
+  (testing "POST /alert-rules/:id/instances/dismiss deletes the named instances"
+    (let [session (h/csrf-session)]
+      (-create-rule! session {:name "Absence" :alert_on "no_result"
+                              :query {:group_by ["service"] :visualization {:type "table"}}})
+      (let [rule-id (:id (first (-list-rules)))]
+        ;; Seed two tracked instances directly (the eval path is covered by
+        ;; the absence-group integration test; here we test the route).
+        (instance-store/upsert! (sqlite) {:rule_id rule-id :fingerprint "fp-a"
+                                          :labels {:service "a"} :state :firing
+                                          :first_seen 1 :last_seen 1 :started_at 1})
+        (instance-store/upsert! (sqlite) {:rule_id rule-id :fingerprint "fp-b"
+                                          :labels {:service "b"} :state :ok
+                                          :first_seen 1 :last_seen 1})
+        (is (= 2 (count (:instances (-edit-props rule-id)))))
+
+        (let [response (h/post-mutation
+                         (str "/alert-rules/" rule-id "/instances/dismiss")
+                         session {:fingerprints ["fp-a"]})]
+          (is (= 303 (h/status response)))
+          (is (= (str "/alert-rules/" rule-id "/edit") (h/header response "location")))
+          (let [remaining (:instances (-edit-props rule-id))]
+            (is (= 1 (count remaining)) "only the un-dismissed instance remains")
+            (is (= "fp-b" (:fingerprint (first remaining))))))))))

--- a/skills/o11ylite/docs/alert-rules.md
+++ b/skills/o11ylite/docs/alert-rules.md
@@ -36,9 +36,10 @@ This differs from the dashboard metrics API, which sub-buckets results for plott
 |--------|-----------------------------|-----------------------|
 | GET    | `/alert-rules`              | List all alert rules  |
 | POST   | `/alert-rules`              | Create a new rule     |
-| GET    | `/alert-rules/:id/edit`     | Get a single rule     |
+| GET    | `/alert-rules/:id/edit`     | Get a single rule + its tracked instances |
 | PUT    | `/alert-rules/:id`          | Update a rule         |
 | DELETE | `/alert-rules/:id`          | Delete a rule         |
+| POST   | `/alert-rules/:id/instances/dismiss` | Dismiss tracked alert instances by fingerprint |
 
 ---
 
@@ -84,11 +85,12 @@ This differs from the dashboard metrics API, which sub-buckets results for plott
 ```json
 {
   "alert_rule": { ... },
+  "instances": [ ... ],
   "errors": {}
 }
 ```
 
-Same shape as a list item. `errors` is populated only after a failed mutation redirect.
+Same shape as a list item. `instances` is the rule's tracked alert instances (one per active group — see "Tracked instances" below); empty for a rule that has never fired or grouped. `errors` is populated only after a failed mutation redirect.
 
 ---
 
@@ -205,6 +207,25 @@ Same body as create. All fields must be provided (full replacement, not patch).
 No request body.
 
 **Response:** `303` redirect to `/alert-rules`.
+
+---
+
+## Tracked instances and dismissal
+
+A grouped rule (one with `group_by`) tracks state per group; an absence rule (`alert_on: "no_result"`) additionally *retains* each group it has seen so it can fire when that group later disappears. These tracked instances are returned in the `instances` prop of `GET /alert-rules/:id/edit`.
+
+To stop tracking a group — e.g. a service legitimately decommissioned, so its absence is no longer an alert — dismiss its instance:
+
+**POST** `/alert-rules/:id/instances/dismiss` (Inertia write)
+
+**Request body:**
+```json
+{ "fingerprints": ["<fingerprint>", "..."] }
+```
+
+Each fingerprint identifies a tracked instance (the `fingerprint` field of an `instances` entry). Dismissal deletes the rows. A dismissed group re-tracks naturally on a later eval: an ungrouped rule re-fires on its next empty eval, a grouped rule re-tracks the next time that group is seen present. Dismissal is not a permanent mute.
+
+**Response:** `303` redirect to `/alert-rules/:id/edit`.
 
 ---
 


### PR DESCRIPTION
## Step 3 of 5: per-group absence alerts + tracked-group dismissal

**Stacked on #191.** Base is `ming/alert-match-per-group`; review only
this diff. GitHub will retarget to `main` as the stack merges.

Two things: lock in per-group **absence** semantics, and add a
**dismissal** path so operators can stop tracking a group.

> **Stack note.** The original plan folded the tracked-groups *UI* into
> this PR. Splitting it out: this PR is backend + API + docs (fully
> REPL/test-verifiable); the Inertia UI to list and dismiss tracked
> groups follows as #4, building on the endpoint and `instances` prop
> landed here. Docs become #5.

### Per-group absence needs no new engine code

The eval loop drives the union of stored and present fingerprints through
the mode-aware transition table, so a grouped absence rule **already**
tracks each group it sees present (as `ok`) and fires that group
independently when it later disappears — the same loop match rules use,
differing only by the transition table. This PR adds the integration
coverage that pins the behavior:

- a grouped absence rule tracks present groups as `ok`, no notification;
- when a tracked group disappears, only that group fires (per-group
  batch entry with its labels), rollup goes `firing`;
- unlike match, a resolved absence group is **retained** (not deleted),
  so it can fire again — and resolves back to `ok` in place when the
  group reappears.

### Dismissal

An absence group is sticky: once seen it is retained forever so it can
fire on disappearance. When a group is legitimately gone for good (a
decommissioned service), the operator needs to stop tracking it.

- **POST** `/alert-rules/:id/instances/dismiss` with
  `{ "fingerprints": [...] }` deletes those instance rows, reusing the
  `delete-fingerprints!` primitive the foundation already shipped.
- **GET** `/alert-rules/:id/edit` now returns the rule's tracked
  `instances` in its props, so a client can list and dismiss them.

**Semantics — delete, then re-track naturally.** A dismissed group is
*not* permanently muted: an ungrouped rule re-fires on its next empty
eval, a grouped rule re-tracks the next time the group is seen present.
This is the minimal choice — no new persistent suppression state. If a
permanent mute is wanted later, that's an additive change (a tombstone
table or `muted` flag), not a rework of this. **Flag if you'd rather
dismissal suppress permanently** — it changes the data model, so better
to decide now than after the UI consumes it.

### Tests

- `alert-absence-group-test` (integration): grouped absence
  track-then-fire-per-group, and resolve-without-delete.
- `alert-rules-test` (routes): the dismiss endpoint deletes the named
  instances and redirects; the edit page exposes the `instances` prop.
- Full alert suite green: 49 tests, 230 assertions, 0 failures.

### Skill docs

`skills/o11ylite/docs/alert-rules.md` updated: the new endpoint, the
`instances` prop on the edit page, and a tracked-instances/dismissal
section.

### Stack

1. #190 — foundation
2. #191 — match per-group + enrichment + cap
3. **#(this)** — absence per-group + dismissal (backend + API)
4. tracked-groups UI
5. docs

🤖 Generated with [Hermes](https://hermes-agent.nousresearch.com)
