### PR TITLE
feat(frontend): tracked-instances UI on alert rule edit page

### DIFF
--- a/frontend/src/components/alert-rules/tracked-instances.tsx
+++ b/frontend/src/components/alert-rules/tracked-instances.tsx
@@ -1,0 +1,83 @@
+import { router } from "@inertiajs/react"
+import { Trash2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { AlertStateBadge } from "@/components/alert-rules/alert-state-badge"
+import type { AlertInstance } from "@/types"
+
+function formatLabels(labels: Record<string, unknown>): string {
+  const entries = Object.entries(labels)
+  if (entries.length === 0) return "(all results)"
+  return entries
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${String(v)}`)
+    .join(", ")
+}
+
+function dismiss(ruleId: string, instance: AlertInstance) {
+  const label = formatLabels(instance.labels)
+  if (!confirm(`Stop tracking instance "${label}"? It will re-track if seen again.`)) return
+  router.post(`/alert-rules/${ruleId}/instances/dismiss`, {
+    fingerprints: [instance.fingerprint],
+  })
+}
+
+export function TrackedInstances({
+  ruleId,
+  instances,
+}: {
+  ruleId: string
+  instances: AlertInstance[]
+}) {
+  if (instances.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No tracked instances yet. Instances appear here once the rule has evaluated.
+      </p>
+    )
+  }
+
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[80px]">State</TableHead>
+            <TableHead>Group</TableHead>
+            <TableHead className="w-[80px]" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {instances.map((instance) => (
+            <TableRow key={instance.fingerprint}>
+              <TableCell>
+                <AlertStateBadge state={instance.state} />
+              </TableCell>
+              <TableCell>
+                <span className="font-mono text-sm">{formatLabels(instance.labels)}</span>
+              </TableCell>
+              <TableCell>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Dismiss instance"
+                  onClick={() => dismiss(ruleId, instance)}
+                >
+                  <Trash2 size={16} />
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/frontend/src/pages/AlertRuleEdit.tsx
+++ b/frontend/src/pages/AlertRuleEdit.tsx
@@ -3,15 +3,18 @@ import { router, usePage } from "@inertiajs/react"
 
 import ApplicationLayout from "@/components/layouts/application-layout"
 import { AlertRuleForm } from "@/components/alert-rules/alert-rule-form"
+import { TrackedInstances } from "@/components/alert-rules/tracked-instances"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   DEFAULT_QUERY_STATE,
   queryStateFromEntity,
 } from "@/lib/query-helpers"
-import type { AlertRule } from "@/types"
+import type { AlertInstance, AlertRule } from "@/types"
 
 export default function AlertRuleEdit() {
-  const { alert_rule, errors } = usePage<{
+  const { alert_rule, instances, errors } = usePage<{
     alert_rule: AlertRule | null
+    instances?: AlertInstance[]
     errors: Partial<Record<string, string>>
   }>().props
 
@@ -62,6 +65,20 @@ export default function AlertRuleEdit() {
           submitLabel={isEditing ? "Update Rule" : "Create Rule"}
           onSubmit={handleSubmit}
         />
+        {isEditing && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Tracked instances</CardTitle>
+              <CardDescription>
+                Instances this rule is tracking. Dismiss one to stop tracking it;
+                it re-tracks if seen again.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <TrackedInstances ruleId={alert_rule.id} instances={instances ?? []} />
+            </CardContent>
+          </Card>
+        )}
       </div>
     </ApplicationLayout>
   )

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -348,6 +348,22 @@ export interface AlertRule {
   updated_at: number
 }
 
+/**
+ * A tracked alert instance — one per active group of a rule (the empty
+ * fingerprint for ungrouped rules). Returned in the edit page props.
+ */
+export interface AlertInstance {
+  rule_id: string
+  fingerprint: string
+  labels: Record<string, unknown>
+  state: AlertState
+  first_seen: number
+  last_seen: number
+  started_at: number | null
+  resolved_at: number | null
+  last_value: Record<string, unknown> | null
+}
+
 // ============================================================================
 // Notebook Types
 // ============================================================================


### PR DESCRIPTION
Stacked on #192. Final PR in the alert-instances series — the frontend surface for the per-group state + dismissal backend that #190–#192 built.

## What

Surfaces a rule's tracked alert instances on its edit page so operators can see per-instance state and dismiss instances they no longer care about.

- **`TrackedInstances` component** — State/Group table, one row per tracked instance: `AlertStateBadge` (green OK / red Firing) + the group label (`key=value`, or `(all results)` for ungrouped) + a dismiss button.
- **`AlertRuleEdit`** — renders `TrackedInstances` in a card when editing an existing rule; shows empty-state copy ("No tracked instances yet…") before the rule has evaluated.
- **`AlertInstance` type** — matches the `instances` prop the edit route already serves (labels/last_value JSON-parsed server-side).

## Naming

Uses **"instance"** throughout, consistent with the `alert_instances` table, `instance-store`, `list-instances`/`dismiss-instances!`, and the `AlertInstance` type. "Instance" is also correct for ungrouped rules, which have exactly one instance (the empty fingerprint, rendered `(all results)`) — "group" would be a misnomer there.

The table's **Group** column keeps its name: it labels the `group_by` dimension shown in each row, not the tracked entity.

## Dismissal semantics

Dismiss reuses the delete-and-re-track behavior from #192: removing an instance is **not** a permanent mute. The instance re-tracks on the next eval where its group is seen (and an ungrouped absence rule re-fires on the next empty eval). The confirm dialog says as much. If we later want a true mute, that's a data-model change, not a UI tweak.

## Verification

- `npm run lint` clean, `npm run build` (tsc + vite) green.
- Rendered live against the dev stack with real telemetry: created a per-name absence rule, drove it to a mix of firing/ok tracked instances, confirmed the table + badges + dismiss buttons render correctly, and confirmed the empty state. Screenshots sent to reviewer in chat (not committed — transient). The post-rename diff is copy-only (group→instance) over that verified layout.

No backend changes here; the route + prop + dismiss endpoint all landed in #192.