### PR TITLE
docs+ux(alert-rules): consolidate instance lifecycle docs, add grouped-absence form hint

### DIFF
--- a/frontend/src/components/alert-rules/alert-instances.tsx
+++ b/frontend/src/components/alert-rules/alert-instances.tsx
@@ -30,7 +30,7 @@ function dismiss(ruleId: string, instance: AlertInstance) {
   })
 }
 
-export function TrackedInstances({
+export function AlertInstances({
   ruleId,
   instances,
 }: {

--- a/frontend/src/components/alert-rules/alert-rule-form.tsx
+++ b/frontend/src/components/alert-rules/alert-rule-form.tsx
@@ -212,6 +212,16 @@ export function AlertRuleForm({
             ? "Define the query condition. The alert fires when the query returns no results (absence detection)."
             : "Define the query condition. The alert fires when the query returns non-empty results."}
         </p>
+        {alertOn === "no_result" && queryState.groupBy.length > 0 && (
+          <div className="rounded-md bg-muted/50 border p-3 flex items-start gap-2">
+            <AlertCircle className="text-muted-foreground shrink-0 mt-0.5" size={16} />
+            <p className="text-sm text-muted-foreground">
+              This alerts when a group it has already seen disappears — it
+              won&apos;t fire for a group it has never observed. To alert when
+              the query returns nothing at all, remove the group-by.
+            </p>
+          </div>
+        )}
         {queryError && (
           <div className="rounded-md bg-destructive/10 border border-destructive/50 p-3 flex items-start gap-2">
             <AlertCircle className="text-destructive shrink-0 mt-0.5" size={16} />

--- a/frontend/src/pages/AlertRuleEdit.tsx
+++ b/frontend/src/pages/AlertRuleEdit.tsx
@@ -3,7 +3,7 @@ import { router, usePage } from "@inertiajs/react"
 
 import ApplicationLayout from "@/components/layouts/application-layout"
 import { AlertRuleForm } from "@/components/alert-rules/alert-rule-form"
-import { TrackedInstances } from "@/components/alert-rules/tracked-instances"
+import { AlertInstances } from "@/components/alert-rules/alert-instances"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   DEFAULT_QUERY_STATE,
@@ -68,14 +68,14 @@ export default function AlertRuleEdit() {
         {isEditing && (
           <Card>
             <CardHeader>
-              <CardTitle>Tracked instances</CardTitle>
+              <CardTitle>Alert instances</CardTitle>
               <CardDescription>
-                Instances this rule is tracking. Dismiss one to stop tracking it;
+                The groups this rule is tracking. Dismiss one to stop tracking it;
                 it re-tracks if seen again.
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <TrackedInstances ruleId={alert_rule.id} instances={instances ?? []} />
+              <AlertInstances ruleId={alert_rule.id} instances={instances ?? []} />
             </CardContent>
           </Card>
         )}

--- a/skills/o11ylite/docs/alert-rules.md
+++ b/skills/o11ylite/docs/alert-rules.md
@@ -8,21 +8,38 @@ Alert rules use **Inertia page routes** — see SKILL.md for the read/write prot
 
 ## Evaluation model
 
-The `alert_on` field controls how query results map to alert state. Every `eval_interval_ms`, the engine runs the query over the trailing `eval_window_ms` window:
+Every `eval_interval_ms`, the engine runs the rule's query over the trailing `eval_window_ms` window and updates alert state. On evaluation failure (validation error, exception), the tick is skipped: the rule keeps its previous state and the error is recorded in `last_eval_error`. A broken evaluation is an operational problem, not an alert condition.
 
-**`alert_on: "result"`** (default — presence detection):
-- Query returns any rows/data points → `firing`
-- Query returns empty → `ok`
+### Alert instances and rollup state
 
-**`alert_on: "no_result"`** (absence detection):
-- Query returns empty → `firing`
-- Query returns any rows/data points → `ok`
+A rule does not hold a single state — it holds one **alert instance** per group, where a group is a distinct combination of the query's `group_by` columns. A rule with no `group_by` has exactly one instance, keyed on the empty fingerprint (shown as `(all results)`). Each instance carries its own state, timestamps, and labels, and is identified by a `fingerprint`.
 
-On evaluation failure (validation error, exception), the rule keeps its previous state. The error is recorded in `last_eval_error`.
+The rule's top-level `state` is a **worst-wins rollup**: `firing` if any instance is firing, otherwise `ok`. Instances are returned in the `instances` prop of `GET /alert-rules/:id/edit`; see "Alert instances and dismissal" below for the read/dismiss mechanics.
 
-There is no separate threshold field. To alert when error count exceeds 100, write a query with `having: {ref: "A", op: ">", value: 100}` — the having clause filters out sub-threshold groups, so a non-empty result means the threshold was breached.
+### `alert_on` — what makes an instance fire
 
-For absence/silence detection (e.g., "service stopped sending events"), use `alert_on: "no_result"`. For threshold-based absence (e.g., "QPS dropped below 10"), invert the query to evidence of health (`having count >= 10`) and use `alert_on: "no_result"` — silence fires because there's no evidence of health.
+The `alert_on` field controls how query results map to instance state:
+
+**`alert_on: "result"`** (presence detection): an instance fires when its group appears in results.
+**`alert_on: "no_result"`** (absence detection): an instance fires when its group is missing from results.
+
+There is no separate threshold field. To alert when error count exceeds 100, write a query with `having: {ref: "A", op: ">", value: 100}` — the having clause filters out sub-threshold groups, so a group present in the result means the threshold was breached. For threshold-based absence (e.g., "QPS dropped below 10"), invert the query to evidence of health (`having count >= 10`) and use `alert_on: "no_result"` — the alert fires because there's no evidence of health.
+
+### Per-instance lifecycle
+
+What happens when a group stops breaching differs by mode, because "no breach" means different things:
+
+- **Match (`alert_on: "result"`)** — an instance is tracked only while it breaches. It is minted `firing` the tick its group first appears, and **deleted** the tick the group clears (after a `resolved` notification). A match rule's instance list therefore shows only *currently firing* groups, and is empty when all is well. A cleared group re-fires from scratch if it breaches again.
+- **Absence (`alert_on: "no_result"`)** — an instance is tracked as `ok` once its group is seen present, fires when the group later disappears, and resolves back to `ok` (**retained, not deleted**) when the group reappears. An absence rule's instance list shows every group it is watching, firing or not.
+
+### Absence only fires for groups it has seen
+
+An absence rule can only fire for a group it has previously observed *present* — it has no way to know a group "should" exist otherwise. This has a consequence worth understanding when authoring rules:
+
+- A **grouped** absence rule whose query returns nothing on a cold start (no instances tracked yet) fires nothing — there is no group to mark absent. It begins firing only after it has seen groups appear and then disappear. Use this for *"which of the groups I've seen disappeared?"* (the firing notification's labels tell you which).
+- An **ungrouped** absence rule (no `group_by`) has its single empty-fingerprint instance tracked from creation, so it fires the first time results come back empty — no warm-up. Use this for *"did this query return nothing at all?"*
+
+If you want an alert that fires when a query returns nothing, **drop `group_by` and use an ungrouped absence rule.** (The rule form shows a hint to this effect when you combine `no_result` with a group-by.)
 
 ### Aggregation window (metrics mode)
 
@@ -36,10 +53,10 @@ This differs from the dashboard metrics API, which sub-buckets results for plott
 |--------|-----------------------------|-----------------------|
 | GET    | `/alert-rules`              | List all alert rules  |
 | POST   | `/alert-rules`              | Create a new rule     |
-| GET    | `/alert-rules/:id/edit`     | Get a single rule + its tracked instances |
+| GET    | `/alert-rules/:id/edit`     | Get a single rule + its alert instances |
 | PUT    | `/alert-rules/:id`          | Update a rule         |
 | DELETE | `/alert-rules/:id`          | Delete a rule         |
-| POST   | `/alert-rules/:id/instances/dismiss` | Dismiss tracked alert instances by fingerprint |
+| POST   | `/alert-rules/:id/instances/dismiss` | Dismiss alert instances by fingerprint |
 
 ---
 
@@ -90,7 +107,7 @@ This differs from the dashboard metrics API, which sub-buckets results for plott
 }
 ```
 
-Same shape as a list item. `instances` is the rule's tracked alert instances (one per active group — see "Tracked instances" below); empty for a rule that has never fired or grouped. `errors` is populated only after a failed mutation redirect.
+Same shape as a list item. `instances` is the rule's alert instances (one per group — see "Evaluation model" above and "Alert instances and dismissal" below); empty for a rule that has never evaluated or matched. `errors` is populated only after a failed mutation redirect.
 
 ---
 
@@ -210,9 +227,9 @@ No request body.
 
 ---
 
-## Tracked instances and dismissal
+## Alert instances and dismissal
 
-A grouped rule (one with `group_by`) tracks state per group; an absence rule (`alert_on: "no_result"`) additionally *retains* each group it has seen so it can fire when that group later disappears. These tracked instances are returned in the `instances` prop of `GET /alert-rules/:id/edit`.
+Each alert instance represents one tracked group of a rule (see "Evaluation model" → "Alert instances and rollup state" for the concept and per-mode lifecycle). Instances are read from the `instances` prop of `GET /alert-rules/:id/edit`.
 
 To stop tracking a group — e.g. a service legitimately decommissioned, so its absence is no longer an alert — dismiss its instance:
 
@@ -223,7 +240,7 @@ To stop tracking a group — e.g. a service legitimately decommissioned, so its 
 { "fingerprints": ["<fingerprint>", "..."] }
 ```
 
-Each fingerprint identifies a tracked instance (the `fingerprint` field of an `instances` entry). Dismissal deletes the rows. A dismissed group re-tracks naturally on a later eval: an ungrouped rule re-fires on its next empty eval, a grouped rule re-tracks the next time that group is seen present. Dismissal is not a permanent mute.
+Each fingerprint identifies an instance (the `fingerprint` field of an `instances` entry). Dismissal deletes those rows; it is **not** a permanent mute. A dismissed instance re-tracks naturally on a later eval — an ungrouped rule re-fires on its next empty eval, a grouped rule re-tracks the next time that group is seen present.
 
 **Response:** `303` redirect to `/alert-rules/:id/edit`.
 


### PR DESCRIPTION
PR 5 of the alert-instances series, expanded per review. Addresses the grouped-absence cold-start gap (Q2): a grouped absence rule only fires for a group it has already seen present, so a cold-start empty query fires nothing.

## Docs — `skills/o11ylite/docs/alert-rules.md`

Holistic pass on the now-stale Evaluation model (it predated the per-group engine and described firing only at the rollup level):

- **Rewrites Evaluation model around alert instances** — a rule holds one instance per group; top-level `state` is a worst-wins rollup.
- **Documents the per-mode lifecycle** — match instances are deleted on resolve; absence instances are retained as `ok`.
- **Documents the grouped-vs-ungrouped absence distinction** and the cold-start behavior, with the guidance: to alert on "query returned nothing at all", use an ungrouped absence rule.
- **Consolidates** the old separate "Tracked instances" section into endpoint mechanics that reference the model (no duplicated lifecycle prose).

## UX — `alert-rule-form.tsx`

Adds an inline hint in the Query section, shown only when `alert_on=no_result` **and** a group-by is set: explains the rule only fires for groups it has seen, and to remove the group-by to alert on the query returning nothing at all. Catches the misunderstanding at authoring time, where the decision is made — no new state, no semantic change. Screenshot sent to reviewer in chat.

## Naming consistency

Settles on **"alert instance"** as the entity noun across docs and UI; "group" is used only for what an instance is *keyed on*. Renames the edit-page card and component `TrackedInstances` → `AlertInstances` (file `tracked-instances.tsx` → `alert-instances.tsx`) to match — closing the last "Tracked instances" label left over from #193.

Verified: `npm run lint` + `npm run build` green; form hint rendered live against the dev stack.

No backend changes.