### PR TITLE
fix(skill/auth): parse Inertia version from page-data script tag

### DIFF
--- a/skills/o11ylite/auth.py
+++ b/skills/o11ylite/auth.py
@@ -107,13 +107,17 @@ def _save_credentials(data: dict) -> None:
 
 
 def _discover_inertia_version(base_url: str, token: str) -> str:
-    """GET /explore and extract the Inertia version from the data-page attribute.
+    """GET /explore and extract the Inertia version from the page-data script tag.
 
     We use /explore rather than / because / redirects to /explore, and
     urllib's redirect handling may not follow all redirect types cleanly.
 
     The Authorization header is required: on auth-gated deployments /explore
-    will not return the HTML shell (with the data-page attribute) without it.
+    will not return the HTML shell (with the page-data script) without it.
+
+    Inertia v3 embeds the initial page data in a
+    `<script data-page="app" type="application/json">{...}</script>` tag body;
+    `data-page` is the mount element id, not the payload.
     """
     req = urllib.request.Request(
         base_url + "/explore",
@@ -128,10 +132,13 @@ def _discover_inertia_version(base_url: str, token: str) -> str:
     except urllib.error.URLError as exc:
         _die(f"Failed to reach {base_url}: {exc}")
 
-    # Parse: <div id="app" data-page="...">
-    match = re.search(r'data-page="([^"]+)"', body)
+    # Parse the Inertia page-data script body:
+    # <script data-page="app" type="application/json">{...}</script>
+    match = re.search(
+        r'<script[^>]*\bdata-page="app"[^>]*>(.*?)</script>', body, re.DOTALL
+    )
     if not match:
-        _die("Could not find Inertia data-page attribute in response from /")
+        _die("Could not find Inertia page-data script tag in response from /explore")
 
     page_json = html.unescape(match.group(1))
     try:


### PR DESCRIPTION
The agent auth script (`skills/o11ylite/auth.py`) could never complete authentication — every run died with `error: Could not parse Inertia page data JSON`.

## Problem

`_discover_inertia_version` extracts the Inertia asset version from the `/explore` HTML shell using `re.search(r'data-page="([^"]+)"', body)`. That regex assumes the old Inertia convention where page data lived in a `data-page="<escaped-json>"` attribute on the mount div.

The Inertia v3 template (`backend/src/o11ylite/inertia/template.clj`) renders initial page data as the **body** of a script tag:

```html
<script data-page="app" type="application/json">{"component":...,"version":"1387819824"}</script>
```

Here `data-page="app"` is the mount-element id, not the payload (the template even has a comment saying so). The regex matched `app`, then `json.loads("app")` threw, and the flow aborted before returning a token — so both the API-key and OAuth paths were dead.

## Fix

Match the script-tag body instead:

```python
re.search(r'<script[^>]*\bdata-page="app"[^>]*>(.*?)</script>', body, re.DOTALL)
```

`html.unescape` + `json.loads` + `version` extraction are unchanged.

## Testing

Verified end-to-end against a live deployment with `O11YLITE_API_KEY` set — cached, fresh, and `--refresh` runs all return the correct `inertia_version`. No behavior change other than the parse:

```
$ python3 skills/o11ylite/auth.py "$O11YLITE_URL"
{"token": "...", "base_url": "...", "inertia_version": "1387819824"}
```