### PR TITLE
chore(deps): update duckdb_jdbc to 1.5.5.1

### DIFF
--- a/backend/deps.edn
+++ b/backend/deps.edn
@@ -52,7 +52,7 @@
   javax.annotation/javax.annotation-api {:mvn/version "1.3.2"}
 
   ;; DuckDB
-  org.duckdb/duckdb_jdbc {:mvn/version "1.5.5.0"}
+  org.duckdb/duckdb_jdbc {:mvn/version "1.5.5.1"}
 
   ;; SQLite
   org.xerial/sqlite-jdbc {:mvn/version "3.53.2.1"}


### PR DESCRIPTION
Bumps `org.duckdb/duckdb_jdbc` from `1.5.5.0` to `1.5.5.1`.

Upstream changes ([v1.5.5.1](https://github.com/duckdb/duckdb-java/releases/tag/v1.5.5.1)):

- Auto-close the `ResultSet` returned from `Statement.getResultSet` ([duckdb-java#783](https://github.com/duckdb/duckdb-java/pull/783))
- Manifest version bump ([duckdb-java#784](https://github.com/duckdb/duckdb-java/pull/784))

Patch release, no DuckDB engine change (still 1.5.5). The `getResultSet` fix is the only behavioural change; we never call `getResultSet` directly — all result handling goes through `next.jdbc` — so it's inert here.

## Test Plan

- [x] `clojure -P` resolves `duckdb_jdbc-1.5.5.1.jar`
- [x] `make test` — 295 tests, 1579 assertions, 0 failures
