### PR TITLE
chore(chart): make health probes more lenient

### DIFF
--- a/chart/o11ylite/templates/statefulset.yaml
+++ b/chart/o11ylite/templates/statefulset.yaml
@@ -40,12 +40,16 @@ spec:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /api/health
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 10
           {{- if .Values.persistence.enabled }}
           volumeMounts:
             - name: data


### PR DESCRIPTION
Bump liveness/readiness probe tolerances in the StatefulSet so transient slowness (startup, GC pauses) doesn't cause unnecessary restarts or traffic shedding:

- liveness: timeoutSeconds 5, failureThreshold 5 (was 1s / 3)
- readiness: timeoutSeconds 5, failureThreshold 10 (was 1s / 3)