### PR TITLE
Migrate displayed fields selector to Base UI Combobox

### DIFF
--- a/frontend/src/components/results/table/displayed-fields-selector.tsx
+++ b/frontend/src/components/results/table/displayed-fields-selector.tsx
@@ -1,23 +1,21 @@
-import { useState } from "react"
-import type { Table } from "@tanstack/react-table"
-import { Check, ChevronDown, RotateCcw } from "lucide-react"
+import type { Column, Table } from "@tanstack/react-table"
+import { Check, RotateCcw } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-} from "@/components/ui/command"
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover"
+  Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxLabel,
+  ComboboxList,
+  ComboboxSeparator,
+  ComboboxTrigger,
+} from "@/components/ui/combobox"
 
 import type { RowData } from "./columns"
 
@@ -26,12 +24,15 @@ interface DisplayedFieldsSelectorProps {
   onReset?: () => void
 }
 
+interface FieldGroup {
+  label: string
+  items: Column<RowData, unknown>[]
+}
+
 export function DisplayedFieldsSelector({
   table,
   onReset,
 }: DisplayedFieldsSelectorProps) {
-  const [open, setOpen] = useState(false)
-
   const columns = table
     .getAllColumns()
     .filter((column) => column.getCanHide())
@@ -42,87 +43,81 @@ export function DisplayedFieldsSelector({
 
   const visibleColumns = columns.filter((col) => col.getIsVisible())
   const hiddenColumns = columns.filter((col) => !col.getIsVisible())
+  const groups: FieldGroup[] = [
+    { label: "Visible", items: visibleColumns },
+    { label: "Hidden", items: hiddenColumns },
+  ].filter((group) => group.items.length > 0)
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button variant="outline" size="sm">
-          Displayed fields ({visibleColumns.length}/{columns.length}){" "}
-          <ChevronDown className="ml-1 h-4 w-4" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-64 p-0" align="end">
-        <Command>
-          <CommandInput placeholder="Search fields..." />
-          <CommandList>
-            <CommandEmpty>No field found.</CommandEmpty>
-            {visibleColumns.length > 0 && (
-              <CommandGroup heading="Visible">
-                {visibleColumns.map((column) => (
-                  <FieldItem
-                    key={column.id}
-                    name={column.id}
-                    visible
-                    onToggle={() => column.toggleVisibility(false)}
-                  />
-                ))}
-              </CommandGroup>
-            )}
-            {hiddenColumns.length > 0 && (
-              <CommandGroup heading="Hidden">
-                {hiddenColumns.map((column) => (
-                  <FieldItem
-                    key={column.id}
-                    name={column.id}
-                    visible={false}
-                    onToggle={() => column.toggleVisibility(true)}
-                  />
-                ))}
-              </CommandGroup>
-            )}
-          </CommandList>
-          {onReset && (
-            <>
-              <CommandSeparator />
-              <div className="p-1">
-                <button
-                  className="text-muted-foreground hover:text-foreground flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm"
-                  onClick={onReset}
-                >
-                  <RotateCcw className="size-4" />
-                  Reset to defaults
-                </button>
-              </div>
-            </>
+    <Combobox<Column<RowData, unknown>>
+      items={groups}
+      value={null}
+      onValueChange={(column, eventDetails) => {
+        if (column) {
+          column.toggleVisibility(!column.getIsVisible())
+          eventDetails.cancel()
+        }
+      }}
+      itemToStringValue={(column) => column.id}
+      itemToStringLabel={(column) => column.id}
+    >
+      <ComboboxTrigger render={<Button variant="outline" size="sm" />}>
+        Displayed fields ({visibleColumns.length}/{columns.length})
+      </ComboboxTrigger>
+      <ComboboxContent className="w-max" align="end">
+        <ComboboxInput showTrigger={false} placeholder="Search fields..." />
+        <ComboboxEmpty>No field found.</ComboboxEmpty>
+        <ComboboxList>
+          {(group: FieldGroup) => (
+            <ComboboxGroup
+              key={group.label}
+              items={group.items}
+              className="pb-2 last:pb-0"
+            >
+              <ComboboxLabel>{group.label}</ComboboxLabel>
+              <ComboboxCollection>
+                {(column: Column<RowData, unknown>) => (
+                  <ComboboxItem key={column.id} value={column}>
+                    <VisibilityCheckbox visible={column.getIsVisible()} />
+                    <span className="min-w-0 flex-1 break-words">
+                      {column.id}
+                    </span>
+                  </ComboboxItem>
+                )}
+              </ComboboxCollection>
+            </ComboboxGroup>
           )}
-        </Command>
-      </PopoverContent>
-    </Popover>
+        </ComboboxList>
+        {onReset && (
+          <>
+            <ComboboxSeparator />
+            <div className="p-1">
+              <button
+                className="text-muted-foreground hover:text-foreground flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm"
+                onClick={onReset}
+              >
+                <RotateCcw className="size-4" />
+                Reset to defaults
+              </button>
+            </div>
+          </>
+        )}
+      </ComboboxContent>
+    </Combobox>
   )
 }
 
-function FieldItem({
-  name,
-  visible,
-  onToggle,
-}: {
-  name: string
-  visible: boolean
-  onToggle: () => void
-}) {
+function VisibilityCheckbox({ visible }: { visible: boolean }) {
   return (
-    <CommandItem value={name} onSelect={onToggle}>
-      <div
-        className={cn(
-          "flex size-4 shrink-0 items-center justify-center rounded-sm border",
-          visible
-            ? "border-primary bg-primary text-primary-foreground"
-            : "border-muted-foreground/40"
-        )}
-      >
-        {visible && <Check className="size-3" />}
-      </div>
-      {name}
-    </CommandItem>
+    <div
+      className={cn(
+        "flex size-4 shrink-0 items-center justify-center rounded-sm border",
+        visible
+          ? "border-primary bg-primary text-primary-foreground"
+          : "border-muted-foreground/40"
+      )}
+    >
+      {visible && <Check className="size-3" />}
+    </div>
   )
 }


### PR DESCRIPTION
Migrates `DisplayedFieldsSelector` from the Command+Popover pattern to the new shadcn Base UI `Combobox`, completing the migration started in #291.

## Changes
- Swapped `ui/command` + `ui/popover` for `ui/combobox` primitives; public props (`table`, `onReset`) unchanged
- Uses the Combobox **grouped items** mode (official Base UI pattern) for the Visible/Hidden sections with live search filtering
- `onValueChange` toggles visibility and cancels the selection (`eventDetails.cancel()`) so the popup stays open while toggling
- `value={null}` + controlled selection keeps the right-side item indicator from rendering (checkbox is the visible state)
- `ComboboxContent className="w-max"` — popup now sizes to content (e.g. 432px) instead of the fixed `w-64`, so long field names like `attr.o11ylite.store_init.metrics_partition_buckets` don't wrap
- Popup width verified in browser; search, empty state, reset, keyboard nav all working

## Notes
- `ui/command.tsx` is now unused by the app (kept in the repo for now; `ui/popover.tsx` is still used by the time range selector and time series settings)
- The popup closing after a toggle is **pre-existing behavior**: toggling a field updates `visualization` which is part of the query payload (`buildEventsPayload`), causing a refetch that remounts `ResultsTable`. The old implementation closed the popup the same way — could be a follow-up to exclude `displayed_fields` from the query key