### PR TITLE
Fix Combobox popups inside modal dialogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ pom.xml.asc
 
 __pycache__/
 .bk.yaml
+
+# playwright-cli browser automation artifacts
+.playwright-cli/

--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { useEffect } from "react"
 import { Combobox as ComboboxPrimitive } from "@base-ui/react"
 import { CheckIcon, ChevronDownIcon, XIcon } from "lucide-react"
 
@@ -12,6 +13,7 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from "@/components/ui/input-group"
+import { usePortalContainer } from "@/components/ui/portal-container"
 
 const Combobox = ComboboxPrimitive.Root
 
@@ -102,14 +104,35 @@ function ComboboxContent({
     ComboboxPrimitive.Positioner.Props,
     "side" | "align" | "sideOffset" | "alignOffset" | "anchor"
   >) {
+  const portalContainer = usePortalContainer()
+  const insideModalDialog = portalContainer !== null
+
+  useEffect(() => {
+    if (!insideModalDialog) {
+      return
+    }
+    // Radix dialogs listen for Escape on document capture, which fires before
+    // Base UI's document-level handler. Prevent default so the dialog stays
+    // open; Base UI still closes the popup itself.
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault()
+      }
+    }
+    window.addEventListener("keydown", handleEscape, { capture: true })
+    return () =>
+      window.removeEventListener("keydown", handleEscape, { capture: true })
+  }, [insideModalDialog])
+
   return (
-    <ComboboxPrimitive.Portal>
+    <ComboboxPrimitive.Portal container={portalContainer ?? undefined}>
       <ComboboxPrimitive.Positioner
         side={side}
         sideOffset={sideOffset}
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
+        positionMethod={insideModalDialog ? "fixed" : "absolute"}
         className="isolate z-50"
       >
         <ComboboxPrimitive.Popup

--- a/frontend/src/components/ui/portal-container.tsx
+++ b/frontend/src/components/ui/portal-container.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { createContext, useContext } from "react"
+import type { RefObject } from "react"
+
+// Radix modal dialogs set `pointer-events: none` on <body> and trap focus to
+// their own subtree, so popups (e.g. Combobox) that portal to <body> become
+// unclickable and unfocusable. Dialogs provide their content element through
+// this context so popups can portal into it instead.
+export const PortalContainerContext =
+  createContext<RefObject<HTMLElement | null> | null>(null)
+
+export function usePortalContainer() {
+  return useContext(PortalContainerContext)
+}

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -1,10 +1,12 @@
 "use client"
 
 import * as React from "react"
+import { useRef } from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { XIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { PortalContainerContext } from "@/components/ui/portal-container"
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />
@@ -52,10 +54,12 @@ function SheetContent({
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: "top" | "right" | "bottom" | "left"
 }) {
+  const contentRef = useRef<HTMLDivElement>(null)
   return (
     <SheetPortal>
       <SheetOverlay />
       <SheetPrimitive.Content
+        ref={contentRef}
         data-slot="sheet-content"
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
@@ -71,7 +75,9 @@ function SheetContent({
         )}
         {...props}
       >
-        {children}
+        <PortalContainerContext.Provider value={contentRef}>
+          {children}
+        </PortalContainerContext.Provider>
         <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>


### PR DESCRIPTION
The query builder pickers (metric/field/aggregation) were completely unclickable and unfocusable when opened from a drawer such as the notebook "Edit Cell" sheet.

## Root cause
Radix modal dialogs make everything outside the dialog subtree inert:
- `pointer-events: none` is set on `<body>` (the sheet content overrides it with `auto`)
- the dialog's `FocusScope` redirects any focus landing outside the dialog subtree back inside

Base UI popups portal to `<body>`, so inside a modal Sheet they inherit `pointer-events: none` (all clicks pass through) and the focus trap steals focus from the search input (typing goes nowhere). Radix's own Select survives because it sets inline `pointer-events: auto` and pauses the dialog's FocusScope via its layer system — Base UI popups are not part of that.

## Fix
- New `PortalContainerContext`: `SheetContent` provides its content element (frontend/src/components/ui/portal-container.tsx, sheet.tsx)
- `ComboboxContent` portals the popup into that element instead of `<body>` when available, and switches to `position: fixed` so the popup isn't clipped by the scrollable sheet content
- Escape guard: Radix listens on document-capture, which fires before Base UI's document-level handler, so without a guard pressing Esc would close the whole sheet. A window-capture `preventDefault` keeps the sheet open while Base UI still closes the popup (matching the Esc behavior of Radix Select inside a dialog)

Verified in browser: search, keyboard focus, and item selection all work in both pickers inside the drawer; Esc closes only the popup; the explore-page pickers (body-portal path) are unchanged.