### PR TITLE
Introduce O11YLITE_EVENTS_PARTITION_BUCKETS

### DIFF
--- a/backend/src/o11ylite/components/core_config.clj
+++ b/backend/src/o11ylite/components/core_config.clj
@@ -153,7 +153,13 @@
     :env-var     "O11YLITE_METRICS_PARTITION_BUCKETS"
     :default     20
     :parser      #(Long/parseLong %)
-    :description "Number of buckets for metrics table partitioning via DuckLake bucket(N, name) transform."}])
+    :description "Number of buckets for metrics table partitioning via DuckLake bucket(N, name) transform."}
+
+   {:key         :events-partition-buckets
+    :env-var     "O11YLITE_EVENTS_PARTITION_BUCKETS"
+    :default     8
+    :parser      #(Long/parseLong %)
+    :description "Number of buckets for events table partitioning via DuckLake bucket(N, service) transform."}])
 
 ;; ---------------------------------------------------------
 ;; Generated Configuration Maps

--- a/backend/src/o11ylite/store/init.clj
+++ b/backend/src/o11ylite/store/init.clj
@@ -2,7 +2,7 @@
 ;; o11ylite.store.init
 ;;
 ;; DuckLake database initialization
-;; Creates the events table partitioned by day
+;; Creates the events table partitioned by day + service bucket
 ;; ---------------------------------------------------------
 
 (ns o11ylite.store.init
@@ -57,8 +57,13 @@
      \"meta.observed_time\" TIMESTAMP_NS NOT NULL
    )")
 
-(def ^:private set-events-partition-sql
-  "ALTER TABLE o11ylite.events SET PARTITIONED BY (year(timestamp), month(timestamp), day(timestamp), service)")
+(defn- -set-events-partition-sql
+  "Build the ALTER TABLE partition SQL using DuckLake's native bucket() transform.
+   bucket(N, service) distributes rows into N buckets via Murmur3 hash on service name,
+   collapsing the long tail of low-traffic services into a bounded number of partitions."
+  [num-buckets]
+  (format "ALTER TABLE o11ylite.events SET PARTITIONED BY (year(timestamp), month(timestamp), day(timestamp), bucket(%d, service))"
+          num-buckets))
 
 (def ^:private set-events-sorted-sql
   "ALTER TABLE o11ylite.events SET SORTED BY (timestamp DESC)")
@@ -104,16 +109,18 @@
 (defn init-store!
   "Initialize DuckLake database schema.
    Creates the events and metrics tables if they don't exist.
-   Events are partitioned by day + service.
+   Events are partitioned by day + bucket(N, service) where N comes from core config.
    Metrics are partitioned by day + bucket(N, name) where N comes from core config.
 
    Each table's DDL goes through its own writer pool to keep the writer
    contract (one connection per table) consistent. At startup no batchers
    are running yet, so there's no contention."
-  [writer-events writer-metrics {:keys [metrics-partition-buckets]}]
-  (mulog/log ::init-store-starting :o11ylite.store_init.metrics_partition_buckets metrics-partition-buckets)
+  [writer-events writer-metrics {:keys [events-partition-buckets metrics-partition-buckets]}]
+  (mulog/log ::init-store-starting
+             :o11ylite.store_init.events_partition_buckets events-partition-buckets
+             :o11ylite.store_init.metrics_partition_buckets metrics-partition-buckets)
   (jdbc/execute! writer-events [create-events-table-sql])
-  (jdbc/execute! writer-events [set-events-partition-sql])
+  (jdbc/execute! writer-events [(-set-events-partition-sql events-partition-buckets)])
   (jdbc/execute! writer-events [set-events-sorted-sql])
   (jdbc/execute! writer-metrics [create-metrics-table-sql])
   (jdbc/execute! writer-metrics [(-set-metrics-partition-sql metrics-partition-buckets)])

--- a/backend/test/o11ylite/integration/scheduled_jobs/parquet_compaction_test.clj
+++ b/backend/test/o11ylite/integration/scheduled_jobs/parquet_compaction_test.clj
@@ -152,7 +152,7 @@
 (deftest merge-adjacent-files-compacts-data-test
   (testing "After ingesting events, merge returns files-created and files-processed"
     ;; Pin both service and timestamp so all events land in the same
-    ;; year/month/day/service partition. Without a fixed timestamp,
+    ;; year/month/day/bucket(service) partition. Without a fixed timestamp,
     ;; make-random-event picks a random time in the past hour — when the
     ;; test runs near a UTC day boundary, events can straddle two day
     ;; partitions and the merge produces one output file per partition.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,3 @@
-import path from "path"
 import tailwindcss from "@tailwindcss/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
@@ -11,7 +10,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": import.meta.dirname + "/src",
     },
   },
   base: '/frontend',


### PR DESCRIPTION
**Introduce O11YLITE_EVENTS_PARTITION_BUCKETS**

Add a bucket-based partitioning scheme for the events table, mirroring the existing `O11YLITE_METRICS_PARTITION_BUCKETS` mechanism.

- **What changed:** Events are now partitioned by `(year, month, day, bucket(N, service))` instead of `(year, month, day, service)`. Service names are Murmur3-hashed into N buckets, so the per-day partition count is bounded by N regardless of how many services emit data.
- **Default:** N = 8 (configurable via `O11YLITE_EVENTS_PARTITION_BUCKETS`).
- **Why:** The old per-service partitioning gave every low-traffic service its own partition, producing many small Parquet files and extra write/compaction load. Bucketing collapses the long tail of services into a fixed number of larger partitions, reducing write amplification and compaction work.
- **Note:** Service-equality filters still prune to a single bucket via the deterministic hash.

Also includes a small unrelated Vite fix (`import.meta.dirname` instead of `path.resolve`).