### PR TITLE
chore: remove unused camel-snake-kebab dependency

### DIFF
--- a/backend/deps.edn
+++ b/backend/deps.edn
@@ -34,7 +34,6 @@
 
   ;; Inertia
   hiccup/hiccup {:mvn/version "2.0.0"}
-  camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
 
   ;; gRPC
   io.grpc/grpc-netty-shaded {:mvn/version "1.83.1"}


### PR DESCRIPTION
## Summary

Round of dependency cleanup for both frontend and Clojure backend.

**Backend** — removed `camel-snake-kebab` from `backend/deps.edn`. It was added with the original Inertia integration but no backend code references any of its namespaces anymore.

**Frontend** — no changes. Ran `knip` plus a manual import scan over every dependency and devDependency: all are referenced in `src/`, tests, or config files.

## How unused deps were found

For each lib in `deps.edn`, listed the namespaces/classes inside its jar (from `~/.m2`) and checked every backend source file (`src`, `test`, `dev`, `resources`) for references — including Java imports split as `[package ClassName]` and JDBC/ServiceLoader usage. Every other dep has a live reference, or is load-bearing at build time (generated gRPC/protobuf code) or via JDBC URL (`sqlite-jdbc`, `duckdb_jdbc`).

## Kept intentionally (REPL toolbox)

The `:repl/reloaded` alias bundles `test.check`, `ring-mock`, `criterium`, `tools.trace`, `clj-yaml` — none are referenced in code, but they were curated for interactive REPL use (added together in "increase dev env portability"). Happy to drop them too if you want a stricter cut.

## Verification

- Backend: `make test` — 295 tests, 1581 assertions, 0 failures (needed `make otel-proto-download && make proto-compile` first; generated classes are gitignored)
- Frontend: `npm run build` ✓, `npm run lint` ✓, `npm test` — 65/65 passed